### PR TITLE
修复 Web 控制台加载模型列表时未携带 API Key

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1147,7 +1147,7 @@ async function loadModelTest(){
     const k=(kd.keys||[]).find(x=>!x.revoked&&x.raw);
     if(!k){$('modelTestRows').innerHTML='<tr><td colspan="4" class="empty">请先创建 API Key</td></tr>';return;}
     modelTestKey=k.raw;
-    const d=await api('/v1/models');
+    const d=await api('/v1/models',{headers:{Authorization:'Bearer '+modelTestKey}});
     const models=d.data||[];
     if(!models.length){$('modelTestRows').innerHTML='<tr><td colspan="4" class="empty">暂无可用模型</td></tr>';return;}
     $('modelTestRows').innerHTML=models.map(m=>`<tr data-model="${esc(m.id)}"><td><b>${esc(m.id)}</b></td><td><span class="status"><i></i>未测试</span></td><td style="font-size:12px;color:var(--muted)">-</td><td style="font-size:12px;color:var(--muted)">点击"测试全部"</td></tr>`).join('');


### PR DESCRIPTION

## 问题说明

   Web 控制台的“模型测试”页面在 `/v1/models` 需要 API Key 认证时，无法正常加载可用模型列表。

   页面已经通过管理接口获取到一个有效的 API Key，但在随后请求 `/v1/models` 时没有携带该 Key，导致模型列表加载失败，后续
 的内置模型测试也无法执行。

## 问题原因

   `loadModelTest()` 调用 `/v1/models` 时缺少 `Authorization` 请求头。

   此时页面已经获取并保存了有效的 API Key，而且后续发送模型测试请求时也会使用这个 Key，因此这里只是遗漏了模型列表请求的
 认证信息。

## 修改内容

   请求 `/v1/models` 时，通过 Bearer Token 携带当前有效的 API Key：

   ```javascript
   const d=await api('/v1/models',{
     headers:{Authorization:'Bearer '+modelTestKey}
   });
```
## 验证情况

 - 确认携带有效 API Key 后，/v1/models 可以正常返回模型列表。
 - 确认 Web 控制台能够加载可用模型。
 - 确认可以运行内置模型测试。
 - 确认模型返回内容能够显示在“输出”列。

