### PR TITLE
修复流式响应缺少 finish_reason 导致严格客户端报错

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -730,6 +730,15 @@ type oaiReq struct {
 
 func mustJSON(v any) string { b, _ := json.Marshal(v); return string(b) }
 
+// writeStreamFinish emits a terminal OpenAI-compatible chunk with a non-null
+// finish_reason before the stream ends, so strict clients do not treat an
+// otherwise successful response as incomplete.
+func writeStreamFinish(w http.ResponseWriter, flusher http.Flusher, id, model string) {
+	finishChunk := map[string]any{"id": id, "object": "chat.completion.chunk", "created": time.Now().Unix(), "model": model, "choices": []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"}}}
+	fmt.Fprintf(w, "data: %s\n\n", mustJSON(finishChunk))
+	flusher.Flush()
+}
+
 func contentToString(c any) string {
 	switch v := c.(type) {
 	case string:
@@ -1038,6 +1047,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		emitText(pending.String())
+		writeStreamFinish(w, flusher, id, model)
 		fmt.Fprint(w, "data: [DONE]\n\n")
 		flusher.Flush()
 		if body.User != "" && res.ConversationID != "" {
@@ -1141,6 +1151,7 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 		flusher.Flush()
 		res, err = s.chat.ChatWithDelta(ctx, account, answerReq, emit)
 		if err == nil {
+			writeStreamFinish(w, flusher, id, model)
 			fmt.Fprint(w, "data: [DONE]\n\n")
 			flusher.Flush()
 		} else {
@@ -1248,6 +1259,7 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 		b, _ := json.Marshal(chunk)
 		fmt.Fprintf(w, "data: %s\n\n", b)
 		flusher.Flush()
+		writeStreamFinish(w, flusher, id, model)
 		fmt.Fprintf(w, "data: [DONE]\n\n")
 		flusher.Flush()
 		return


### PR DESCRIPTION
## 问题说明

   OpenAI 兼容的流式响应能够正常输出内容并以 `data: [DONE]` 结束，但在结束前没有发送包含非空 `finish_reason` 的终止
 chunk。

   严格的 OpenAI 兼容客户端（如 Pi）因此报错：

   `Stream ended without finish_reason`

   并将一次已经成功完成的响应误判为未完成，触发重试。

   ## 问题原因

   普通文本流的三条成功路径在输出内容后直接发送 `data: [DONE]`，没有先发送终止 chunk。`[DONE]` 只表示 SSE 数据流传输完
 毕，而 `finish_reason` 表示本次 completion 正常结束，二者是不同层面的信号。

   工具调用路径原本已正确发送 `finish_reason: "tool_calls"`，不受影响。

   ## 修改内容

   新增 `writeStreamFinish` 辅助函数，在成功文本流结束前发送终止 chunk：

   ```go
   finishChunk := map[string]any{
     "id": id, "object": "chat.completion.chunk",
     "created": time.Now().Unix(), "model": model,
     "choices": []map[string]any{{
       "index": 0, "delta": map[string]any{}, "finish_reason": "stop",
     }},
   }
 ```

 应用于三条流式成功路径：

 - ChatWithEvents 普通文本结束路径
 - ChatWithDelta 成功路径
 - one-shot 流式路径

 错误路径保持原有行为（发送 error 事件），工具调用路径的 finish_reason: "tool_calls" 保持不变。

## 验证情况

   - 对配置的全部 13 个模型（gpt-5.2 / gpt-5.2-reasoning / gpt-5.3 / gpt-5.4 / gpt-5.4-reasoning / gpt-5.5 /
 gpt-5.5-reasoning / gpt-5.6-reasoning / claude-sonnet / claude-sonnet-reasoning / gpt-5.6-sol / gpt-5.6-terra /
 gpt-5.6-luna）逐一发送流式请求验证：
     - 全部返回 HTTP 200
     - 全部以 `"finish_reason":"stop"` 终止 chunk 结束
     - 全部在终止 chunk 后正确发送 `data: [DONE]`
     - 无 error 事件

     响应结尾顺序示例：

     `...内容 chunk...` → `{"choices":[{"delta":{},"finish_reason":"stop","index":0}]}` → `data: [DONE]`

   - `go build ./...` 通过