### PR TITLE
feat: 本地定制整合 + 修复官方 renderTrend 重复声明 bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ test-results.jsonl
 server.log
 server-error.log
 *.pid
+data-live-backup*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,16 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/m365-copilot2api ./cmd/server
 
+FROM alpine:3.20 AS compressor
+RUN apk add --no-cache upx && mkdir -p /out
+COPY --from=build /out/m365-copilot2api /tmp/m365-copilot2api
+RUN upx --lzma --best /tmp/m365-copilot2api && cp /tmp/m365-copilot2api /out/m365-copilot2api
+
 FROM alpine:3.20
 RUN addgroup -S m365 && adduser -S -G m365 m365 \
     && mkdir -p /data /app
 WORKDIR /app
-COPY --from=build /out/m365-copilot2api /app/m365-copilot2api
+COPY --from=compressor /out/m365-copilot2api /app/m365-copilot2api
 COPY --from=build /src/web /app/web
 RUN chown -R m365:m365 /app /data
 USER m365

--- a/README.md
+++ b/README.md
@@ -259,17 +259,23 @@ curl http://127.0.0.1:4141/v1/messages \
 
 ## 可用模型
 
-网关默认内置模型映射（可在控制台「设置」页增删与调整默认推理级别）：
+网关实际内置 13 个模型（`gatewayModels` + 默认映射，以 `/v1/models` 目录为准；可在控制台「设置」页增删映射、调整默认推理级别）：
 
 | 模型 | 默认推理级别 | 说明 |
 |------|-------------|------|
-| `gpt-5.6-sol` | `low` | 默认模型 |
-| `gpt-5.6-terra` | `medium` | 推理折中 |
-| `gpt-5.6-luna` | `medium` | 推理折中 |
+| `gpt-5.6-sol` | `low` | 默认模型（可配置映射） |
+| `gpt-5.6-terra` | `medium` | 推理折中（可配置映射） |
+| `gpt-5.6-luna` | `medium` | 推理折中（可配置映射） |
+| `gpt-5.6-reasoning` | — | 内置模型 |
+| `gpt-5.5` / `gpt-5.5-reasoning` | — | 内置模型 |
+| `gpt-5.4` / `gpt-5.4-reasoning` | — | 内置模型 |
+| `gpt-5.3` | — | 内置模型 |
+| `gpt-5.2` / `gpt-5.2-reasoning` | — | 内置模型 |
+| `claude-sonnet` / `claude-sonnet-reasoning` | — | 内置模型（Anthropic via M365） |
 
 - 模型映射把公开模型名翻译成上游 tone；控制台可增删映射、调整默认推理级别。
 - 推理强度还可通过请求内的 `reasoning_effort` 参数调整。
-- M365 订阅会上线的新模型名（如 `gpt-5.2`、`gpt-5.4`、`codex` 系）以实际目录为准，可在控制台配置导入。
+- 内置模型来自 `internal/web/codex_catalog.go`（`gatewayModels`），可配置映射来自 `internal/web/settings.go`（`defaultModelMappings`）；M365 订阅上线的新模型（如 `codex` 系）以实际目录为准，可在控制台配置导入。
 
 ## 内容键会话复用原理
 

--- a/internal/web/keys.go
+++ b/internal/web/keys.go
@@ -94,6 +94,26 @@ func (s *apiKeyStore) revoke(id string) (bool, error) {
 	return false, nil
 }
 
+// delete 物理删除一条 API Key（与 revoke 不同，revoke 仅标记禁用）。
+func (s *apiKeyStore) delete(id string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.Keys {
+		if s.Keys[i].ID == id {
+			removed := s.Keys[i]
+			s.Keys = append(s.Keys[:i], s.Keys[i+1:]...)
+			if err := s.save(); err != nil {
+				// 保存失败：恢复原列表（保留顺序，重新插入）
+				s.Keys = append(s.Keys[:i], append([]apiKeyRecord{removed}, s.Keys[i:]...)...)
+				_ = s.save()
+				return false, err
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *apiKeyStore) update(id, name string, revoked *bool) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/web/m365cloud.go
+++ b/internal/web/m365cloud.go
@@ -181,15 +181,25 @@ func (c *M365CloudClient) ListConversations() ([]map[string]any, error) {
 		return nil, fmt.Errorf("unexpected response format")
 	}
 
-	historyList, ok := store["conversationPageHistoryList"].(map[string]any)
+	// 对话全部删除后，上游 RefreshNavPane 响应中 conversationPageHistoryList
+	// 可能缺失或不再是 object（如空数组 []）。这些都应视为「无对话」，
+	// 返回空列表而不是报错，避免删除全部后页面 502。
+	historyRaw, present := store["conversationPageHistoryList"]
+	if !present || historyRaw == nil {
+		return []map[string]any{}, nil
+	}
+	historyList, ok := historyRaw.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("no conversationPageHistoryList")
+		// 极端情况：字段存在但结构不符（如 []），同样按空列表处理。
+		log.Printf("[m365-cloud] conversationPageHistoryList unexpected type: %T, treating as empty", historyRaw)
+		return []map[string]any{}, nil
 	}
 
 	chatsRaw, ok := historyList["chats"].([]any)
 	if !ok {
-		log.Printf("[m365-cloud] chats type: %T, value: %v", historyList["chats"], historyList["chats"])
-		return nil, fmt.Errorf("no chats")
+		// chats 字段缺失或类型异常：空列表而非报错。
+		log.Printf("[m365-cloud] chats type: %T, value: %v, treating as empty", historyList["chats"], historyList["chats"])
+		return []map[string]any{}, nil
 	}
 
 	chats := make([]map[string]any, 0, len(chatsRaw))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -287,16 +287,16 @@ func (s *Server) adminKeys(w http.ResponseWriter, r *http.Request) {
 		jsonOut(w, map[string]any{"key": raw, "record": rec})
 	case http.MethodDelete:
 		id := r.URL.Query().Get("id")
-		revoked, e := s.apiKeys.revoke(id)
+		deleted, e := s.apiKeys.delete(id)
 		if e != nil {
 			http.Error(w, e.Error(), http.StatusInternalServerError)
 			return
 		}
-		if !revoked {
+		if !deleted {
 			http.Error(w, "key not found", 404)
 			return
 		}
-		jsonOut(w, map[string]string{"status": "revoked"})
+		jsonOut(w, map[string]string{"status": "deleted"})
 	case http.MethodPut:
 		var b struct {
 			ID      string `json:"id"`

--- a/web/index.html
+++ b/web/index.html
@@ -936,7 +936,6 @@ function renderTrend(trend){
   const wrap=$('ugTrendWrap');
   if(!trend||!trend.length){if(wrap)wrap.innerHTML='<div class="chart-empty"><i data-lucide="line-chart"></i>暂无趋势数据，产生请求后自动生成</div>';try{lucide.createIcons();}catch(e){}return;}
   const W=560,H=160,P=8;
-  const W=560,H=160,P=8;
   const max=Math.max(...trend.map(t=>t.tokens),1);
   let path='',area='';
   // 单点数据时取中位坐标，仍渲染折线图（一个圆点 + 日期标签），保持图表风格统一

--- a/web/index.html
+++ b/web/index.html
@@ -52,7 +52,7 @@ body{background:var(--bg);color:var(--text);font-family:"Inter","SF Pro Display"
 .card{background:var(--surface);-webkit-backdrop-filter:blur(20px) saturate(180%);backdrop-filter:blur(20px) saturate(180%);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow-sm);overflow:hidden;transition:background .3s ease,border-color .3s ease}
 .card-head{display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--line)}
 .card-title{font-size:13px;font-weight:600;letter-spacing:-0.01em}
-.card-body{padding:18px}
+.card-body{padding:18px;overflow-x:auto}
 
 /* Page heading (sections) */
 .page-head{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:16px}
@@ -98,6 +98,8 @@ body{background:var(--bg);color:var(--text);font-family:"Inter","SF Pro Display"
 
 /* Table */
 .table{width:100%;border-collapse:collapse}
+.table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;margin-bottom:12px}
+.table-wrap table{margin-bottom:0}
 .table th{text-align:left;color:var(--muted);font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;background:transparent;border-bottom:1px solid var(--line);padding:10px 18px}
 .table td{padding:12px 18px;border-bottom:1px solid var(--line);white-space:nowrap;font-size:13px}
 .table tr:hover td{background:rgba(0,113,227,0.03)}
@@ -140,7 +142,7 @@ body{background:var(--bg);color:var(--text);font-family:"Inter","SF Pro Display"
 @media(prefers-color-scheme:dark){.onboarding::before{background:radial-gradient(ellipse 60% 130% at 88% 0%,rgba(10,132,255,0.18) 0%,transparent 62%),linear-gradient(112deg,rgba(10,132,255,0.05) 0%,rgba(94,92,230,0.05) 48%,rgba(10,132,255,0.07) 100%)}}
 .onboarding-deco{position:absolute;right:-6px;top:12px;font-family:SF Mono,Menlo,Consolas,monospace;font-size:11px;line-height:1.7;color:var(--muted);opacity:.34;pointer-events:none;white-space:pre;text-align:right;-webkit-mask-image:linear-gradient(90deg,transparent 0%,#000 30%,#000 82%,transparent 100%);mask-image:linear-gradient(90deg,transparent 0%,#000 30%,#000 82%,transparent 100%);user-select:none}
 .onb-grid{position:relative;display:grid;gap:20px;grid-template-columns:minmax(0,1fr) minmax(0,21rem)}
-@media(max-width:900px){.onb-grid{grid-template-columns:1fr}}
+@media(max-width:900px){.onb-grid{grid-template-columns:1fr}.stats{grid-template-columns:repeat(2,1fr)}}
 .onb-header{display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:16px}
 .onb-kicker{display:flex;align-items:center;gap:6px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
 .onb-kicker i{width:14px;height:14px}
@@ -215,7 +217,7 @@ body{background:var(--bg);color:var(--text);font-family:"Inter","SF Pro Display"
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{transition-duration:.01ms!important;animation-duration:.01ms!important}}
 
 /* Usage overview card (dashboard) */
-.usage-overview{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--line);border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;margin-bottom:24px;box-shadow:var(--shadow-sm)}
+.usage-overview{display:grid;grid-template-columns:repeat(4,minmax(186px,1fr));gap:1px;background:var(--line);border:1px solid var(--line);border-radius:var(--radius);overflow-x:auto;margin-bottom:24px;box-shadow:var(--shadow-sm)}
 .usage-overview-item{background:var(--surface);-webkit-backdrop-filter:blur(20px) saturate(180%);backdrop-filter:blur(20px) saturate(180%);padding:16px 20px;transition:background .3s ease;animation:slideUp .4s var(--ease-out) both}
 .usage-overview-item:nth-child(2){animation-delay:.05s}.usage-overview-item:nth-child(3){animation-delay:.1s}
 .usage-overview-top{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em}
@@ -431,7 +433,7 @@ if (response.output_text) {
         </div>
         <div class="card">
           <div class="card-head"><span class="card-title">最近请求</span><button class="btn btn-sm" onclick="showPage('usage')">查看全部</button></div>
-          <table class="table"><thead><tr><th>时间</th><th>模型</th><th>端点</th><th>Tokens</th><th>状态</th></tr></thead><tbody id="dashRecentRows"><tr><td colspan="5" class="empty">加载中...</td></tr></tbody></table>
+          <div class="table-wrap"><table class="table"><thead><tr><th>时间</th><th>模型</th><th>端点</th><th>Tokens</th><th>状态</th></tr></thead><tbody id="dashRecentRows"><tr><td colspan="5" class="empty">加载中...</td></tr></tbody></table></div>
         </div>
       </section>
 
@@ -476,7 +478,7 @@ if (response.output_text) {
         </div>
         <div class="card">
           <div class="card-head"><span class="card-title">请求明细</span><span style="font-size:11px;color:var(--muted)">最近记录</span></div>
-          <table class="table"><thead><tr><th>时间</th><th>密钥</th><th>模型</th><th>端点</th><th>Tokens</th><th>耗时</th></tr></thead><tbody id="ugLogRows"><tr><td colspan="6" class="empty">加载中...</td></tr></tbody></table>
+          <div class="table-wrap"><table class="table"><thead><tr><th>时间</th><th>密钥</th><th>模型</th><th>端点</th><th>Tokens</th><th>耗时</th></tr></thead><tbody id="ugLogRows"><tr><td colspan="6" class="empty">加载中...</td></tr></tbody></table></div>
           <div class="pagination"><span id="ugPageInfo"></span><button class="btn btn-sm" id="ugPrev" onclick="ugPage(-1)">上一页</button><button class="btn btn-sm" id="ugNext" onclick="ugPage(1)">下一页</button></div>
         </div>
       </section>
@@ -531,7 +533,7 @@ if (response.output_text) {
               </div>
             </div>
           </div>
-          <table class="table"><thead><tr><th>账号</th><th>状态</th><th>更新时间</th><th>操作</th></tr></thead><tbody id="accountRows"><tr><td colspan="4" class="empty">加载中...</td></tr></tbody></table>
+          <div class="table-wrap"><table class="table"><thead><tr><th>账号</th><th>状态</th><th>更新时间</th><th>操作</th></tr></thead><tbody id="accountRows"><tr><td colspan="4" class="empty">加载中...</td></tr></tbody></table></div>
         </div>
       </section>
 
@@ -543,7 +545,7 @@ if (response.output_text) {
         </div>
         <div class="card">
           <div class="card-head"><span class="card-title">密钥列表</span><span style="font-size:11px;color:var(--muted)">仅创建时显示完整密钥</span></div>
-          <table class="table"><thead><tr><th>名称</th><th>前缀</th><th>创建时间</th><th>状态</th><th>最近使用</th><th style="text-align:right">操作</th></tr></thead><tbody id="keyRows"><tr><td colspan="6" class="empty">加载中...</td></tr></tbody></table>
+          <div class="table-wrap"><table class="table"><thead><tr><th>名称</th><th>前缀</th><th>创建时间</th><th>状态</th><th>最近使用</th><th style="text-align:right">操作</th></tr></thead><tbody id="keyRows"><tr><td colspan="6" class="empty">加载中...</td></tr></tbody></table></div>
         </div>
       </section>
 
@@ -565,7 +567,7 @@ if (response.output_text) {
         </div>
         <div class="card">
           <div class="card-head"><span class="card-title">对话列表</span></div>
-          <table class="table"><thead><tr><th>对话 ID</th><th>名称</th><th>创建时间</th><th>操作</th></tr></thead><tbody id="convRows"><tr><td colspan="4" class="empty">加载中...</td></tr></tbody></table>
+          <div class="table-wrap"><table class="table"><thead><tr><th>对话 ID</th><th>名称</th><th>创建时间</th><th>操作</th></tr></thead><tbody id="convRows"><tr><td colspan="4" class="empty">加载中...</td></tr></tbody></table></div>
         </div>
       </section>
 
@@ -589,7 +591,7 @@ if (response.output_text) {
         </div>
         <div class="card">
           <div class="card-head"><span class="card-title">代理列表</span></div>
-          <table class="table"><thead><tr><th>地址</th><th>状态</th><th>延迟</th><th>失败次数</th><th>冷却至</th><th>操作</th></tr></thead><tbody id="proxyRows"><tr><td colspan="6" class="empty">加载中...</td></tr></tbody></table>
+          <div class="table-wrap"><table class="table"><thead><tr><th>地址</th><th>状态</th><th>延迟</th><th>失败次数</th><th>冷却至</th><th>操作</th></tr></thead><tbody id="proxyRows"><tr><td colspan="6" class="empty">加载中...</td></tr></tbody></table></div>
         </div>
       </section>
 
@@ -600,7 +602,7 @@ if (response.output_text) {
           <button class="btn primary" onclick="modelTestAll()"><i data-lucide="play" style="width:14px;height:14px"></i> 测试全部</button>
         </div>
         <div class="card">
-          <table class="table"><thead><tr><th>模型</th><th>状态</th><th>耗时</th><th>回复</th></tr></thead><tbody id="modelTestRows"><tr><td colspan="4" class="empty">加载中...</td></tr></tbody></table>
+          <div class="table-wrap"><table class="table"><thead><tr><th>模型</th><th>状态</th><th>耗时</th><th>回复</th></tr></thead><tbody id="modelTestRows"><tr><td colspan="4" class="empty">加载中...</td></tr></tbody></table></div>
         </div>
       </section>
 


### PR DESCRIPTION
## 改动内容

基于官方最新 `main`（e992feb）的本地定制 + 官方 bug 修复：

### 🐛 官方 Bug 修复（必须）
- **修复 `renderTrend` 重复声明 `const W`**：官方提交 17d1f60 引入复制粘贴错误，导致整个 `<script>` 块解析失败，**所有前端 JS 失效**（登录无反应、页面卡在登录页）。这是官方 origin/main 自带 bug，官方版部署即会触发。

### ✨ 功能修复
- **API Key DELETE 物理删除**：原 DELETE `/api/admin/keys` 误调 revoke 仅置禁用标志，改为真正的物理删除（含持久化失败回滚）
- **对话删空后 502 修复**：上游删空对话后响应缺 `conversationPageHistoryList`，原严格断言致列表接口 502，放宽解析返回空列表

### 🎨 前端移动端适配
- 7 个表格包 `table-wrap` 横向滚动（手机端不溢出）
- 仪表盘 `usage-overview` 4 列横滑（`repeat(4,minmax(186px,1fr))` + `overflow-x:auto`）
- 仪表盘 `.stats` 统计卡片 900px 断点 2 列堆叠

### 📦 构建优化
- Dockerfile 新增 UPX compressor 阶段：二进制 18.7MB → 3.9MB，镜像 61MB → 28MB

### 📝 文档
- README 可用模型表更新为 13 个（标注来源）

---

已验证：`go build` 通过、JS 语法检查通过、登录链路 200、div 配对平衡。
