### PR TITLE
fix(responses): extract Codex tool catalog from additional_tools input item

### DIFF
--- a/internal/web/codex_additional_tools_test.go
+++ b/internal/web/codex_additional_tools_test.go
@@ -1,0 +1,150 @@
+package web
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// codexAdditionalToolsInput mirrors the shape captured from Codex Desktop
+// 0.147.0: the tool catalog arrives as an `additional_tools` input item whose
+// entries are `namespace` groups, and the top-level tools field is absent.
+func codexAdditionalToolsInput() []any {
+	return []any{
+		map[string]any{
+			"type": "additional_tools",
+			"role": "developer",
+			"tools": []any{
+				map[string]any{
+					"name": "functions",
+					"type": "namespace",
+					"tools": []any{
+						map[string]any{"name": "exec", "type": "custom", "description": "run js", "format": map[string]any{"type": "grammar", "syntax": "lark"}},
+						map[string]any{"name": "wait", "type": "function", "description": "wait", "parameters": map[string]any{"type": "object", "properties": map[string]any{}}},
+					},
+				},
+				map[string]any{
+					"name": "collaboration",
+					"type": "namespace",
+					"tools": []any{
+						map[string]any{"name": "spawn_agent", "type": "function", "description": "spawn", "parameters": map[string]any{"type": "object", "properties": map[string]any{}}},
+					},
+				},
+			},
+		},
+		map[string]any{
+			"type": "message",
+			"role": "user",
+			"content": []any{
+				map[string]any{"type": "input_text", "text": "分析下当前项目"},
+			},
+		},
+	}
+}
+
+func TestResponsesExtractsCodexAdditionalTools(t *testing.T) {
+	r := responsesRequest{Model: "gpt-5.6-sol", Input: codexAdditionalToolsInput(), ToolChoice: "auto"}
+	o, err := r.openAI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(o.Tools) == 0 {
+		t.Fatal("additional_tools were dropped; request would reach ChatHub with no tools")
+	}
+	// The catalog contains a custom exec tool, so the exec bridge takes over and
+	// it must be the single forwarded tool with the string-input schema.
+	if len(o.Tools) != 1 {
+		t.Fatalf("want only the custom exec bridge, got %d tools", len(o.Tools))
+	}
+	if o.Tools[0].Type != "custom" {
+		t.Fatalf("type=%q want custom", o.Tools[0].Type)
+	}
+	var fn struct {
+		Name       string         `json:"name"`
+		Parameters map[string]any `json:"parameters"`
+	}
+	if err := json.Unmarshal(o.Tools[0].Function, &fn); err != nil {
+		t.Fatal(err)
+	}
+	if fn.Name != "exec" {
+		t.Fatalf("name=%q want exec", fn.Name)
+	}
+	props, _ := fn.Parameters["properties"].(map[string]any)
+	if _, ok := props["input"]; !ok {
+		t.Fatalf("exec bridge lost its input schema: %#v", fn.Parameters)
+	}
+}
+
+func TestResponsesAdditionalToolsKeepsUserMessage(t *testing.T) {
+	r := responsesRequest{Model: "gpt-5.6-sol", Input: codexAdditionalToolsInput()}
+	o, err := r.openAI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The additional_tools item must not become a prompt message, and the real
+	// user turn must survive alongside the injected exec instruction.
+	var user int
+	for _, m := range o.Messages {
+		if m.Role == "user" {
+			user++
+			if text := contentToString(m.Content); text != "分析下当前项目" {
+				t.Fatalf("user content=%q", text)
+			}
+		}
+	}
+	if user != 1 {
+		t.Fatalf("user messages=%d want 1: %#v", user, o.Messages)
+	}
+}
+
+func TestResponsesAdditionalToolsWithoutCustomExec(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type": "additional_tools",
+			"tools": []any{
+				map[string]any{
+					"name": "functions",
+					"type": "namespace",
+					"tools": []any{
+						map[string]any{"name": "shell", "type": "function", "description": "run", "parameters": map[string]any{"type": "object", "properties": map[string]any{}}},
+						map[string]any{"name": "update_plan", "type": "function", "description": "plan", "parameters": map[string]any{"type": "object", "properties": map[string]any{}}},
+					},
+				},
+			},
+		},
+		map[string]any{"type": "message", "role": "user", "content": []any{map[string]any{"type": "input_text", "text": "hi"}}},
+	}
+	o, err := responsesRequest{Model: "gpt-5.6-sol", Input: input}.openAI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(o.Tools) != 2 {
+		t.Fatalf("tools=%d want 2", len(o.Tools))
+	}
+	for _, tool := range o.Tools {
+		if tool.Type != "function" {
+			t.Fatalf("type=%q want function", tool.Type)
+		}
+	}
+}
+
+func TestResponsesTopLevelAndInputToolsMerge(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type": "additional_tools",
+			"tools": []any{
+				map[string]any{"name": "update_plan", "type": "function", "description": "plan", "parameters": map[string]any{"type": "object", "properties": map[string]any{}}},
+			},
+		},
+	}
+	o, err := responsesRequest{
+		Model: "gpt-5.6-sol",
+		Input: input,
+		Tools: []map[string]any{{"type": "function", "name": "shell", "description": "run", "parameters": map[string]any{"type": "object", "properties": map[string]any{}}}},
+	}.openAI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(o.Tools) != 2 {
+		t.Fatalf("tools=%d want top-level and input tools merged", len(o.Tools))
+	}
+}

--- a/internal/web/protocol_compat.go
+++ b/internal/web/protocol_compat.go
@@ -35,6 +35,7 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 		o.Reasoning = r.Reasoning
 		o.ReasoningEffort = r.Reasoning.Effort
 	}
+	var inputTools []map[string]any
 	switch v := r.Input.(type) {
 	case string:
 		if v == "" {
@@ -49,6 +50,12 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 			}
 			typ, _ := m["type"].(string)
 			switch typ {
+			case "additional_tools":
+				// Codex Desktop ships its tool catalog as an input item instead of
+				// the top-level tools field. Without this the request reaches
+				// ChatHub with zero tools and the model answers from imagination.
+				inputTools = append(inputTools, flattenAdditionalTools(m)...)
+				continue
 			case "function_call_progress":
 				// Progress is deliberately not converted into an assistant/tool
 				// message. It is transport metadata from a long-running client-side
@@ -97,8 +104,9 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 	default:
 		return o, fmt.Errorf("input must be string or array")
 	}
+	tools := append(append([]map[string]any(nil), r.Tools...), inputTools...)
 	hasCustomExec := false
-	for _, t := range r.Tools {
+	for _, t := range tools {
 		typ, _ := t["type"].(string)
 		name, _ := t["name"].(string)
 		if typ == "custom" && name == "exec" {
@@ -106,7 +114,7 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 			break
 		}
 	}
-	for _, t := range r.Tools {
+	for _, t := range tools {
 		typ, _ := t["type"].(string)
 		name, _ := t["name"].(string)
 		if hasCustomExec && !(typ == "custom" && name == "exec") {
@@ -129,6 +137,30 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 		o.Messages = append([]oaiMsg{{Role: "system", Content: customExecWorkspaceInstruction}}, o.Messages...)
 	}
 	return o, nil
+}
+
+// flattenAdditionalTools unwraps a Codex `additional_tools` input item. Its
+// tools list mixes plain tool definitions with `namespace` groups that nest a
+// further tools array, so collect the leaves from both shapes.
+func flattenAdditionalTools(item map[string]any) []map[string]any {
+	raw, _ := item["tools"].([]any)
+	out := make([]map[string]any, 0, len(raw))
+	for _, entry := range raw {
+		t, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if nested, ok := t["tools"].([]any); ok {
+			for _, child := range nested {
+				if c, ok := child.(map[string]any); ok {
+					out = append(out, c)
+				}
+			}
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }
 
 type anthropicMessage struct {


### PR DESCRIPTION
## 问题

用 Codex Desktop（0.147.0）通过网关的 `/v1/responses` 对话时，模型完全不调用工具，转而凭空编造执行结果——包括一个它从未检查过的 `/mnt/data` 工作目录，并伴随大段重复输出。

网关日志显示工具在解析阶段就丢光了：

```
stage=body_parsed messages=7 tools=0 choice=auto raw_bytes=57225
```

## 根因

Codex 不把工具目录放在顶层 `tools` 字段，而是作为一个 `additional_tools` input item 下发，其中的条目还是 `namespace` 分组，内部再嵌一层 `tools` 数组：

```json
{
  "input": [
    { "type": "additional_tools", "role": "developer",
      "tools": [
        { "name": "functions", "type": "namespace",
          "tools": [ {"type":"custom","name":"exec"}, {"type":"function","name":"wait"} ] },
        { "name": "collaboration", "type": "namespace", "tools": [...] }
      ] },
    { "type": "message", "role": "user", "content": [...] }
  ]
}
```

顶层 `tools` 字段根本不存在，而 `responsesRequest.openAI()` 只读顶层字段，于是请求以零工具送达 ChatHub，模型手里没有任何执行能力，只能靠想象作答。

这个 item 还会落入 `default` 分支，变成一条约 21KB 的伪 user 消息，把原始工具 JSON 灌进提示词。

## 改动

`internal/web/protocol_compat.go`：

- 在 input 循环中新增 `additional_tools` 分支，提取工具后 `continue`，避免它被当作提示词消息
- 新增 `flattenAdditionalTools()`，同时兼容 `namespace` 分组与裸工具定义两种形状
- 工具转换改为合并顶层 `tools` 与 input 中提取的工具；原有的 custom exec 独占逻辑保持不变

## 测试

新增 `internal/web/codex_additional_tools_test.go`，fixture 直接取自抓取到的真实 Codex 请求结构，覆盖：工具提取、custom exec 桥接 schema、user 消息不被污染、无 custom exec 的纯 function 场景、顶层与 input 工具合并。

验证情况：

- `go build ./...` 通过
- 新增测试及既有 `Responses`/`Codex` 相关测试全部通过
- Docker 重建后实测：同样形状的请求由 `tools=0` 变为 `tools=1`，并正确返回 `custom_tool_call`（`input: "pwd && ls"`）

补充说明：`internal/web/` 中有 9 个预先存在的失败用例（`TempDir: stat ... no such file or directory`），在未打补丁的干净树上同样复现，与本次改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)