### PR TITLE
feat(web): 默认注入 BingWebSearch 内建插件启用联网搜索

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ docker compose up -d --build
 | `M365_CLIENT_ID` | 内置 | Azure 应用 Client ID |
 | `M365_AUTHORITY` / `M365_REDIRECT_URI` / `M365_SCOPE` | 内置 | OAuth 端点自定义覆盖 |
 
+### 工具与网络搜索
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `M365_ENABLE_WEB_SEARCH` | 开 | 自动注入 `web_search` 声明（`0` / `false` / `off` 关闭）。开启后每次对话都会像 M365 网页版那样注册 BingWebSearch 内建插件，模型可基于实时搜索结果作答 |
+
+> 说明：`web_search` 是服务端内建工具（`BingWebSearch`），不会出现在下发给客户端的 `tool_calls` 里；搜索结果以 `SearchResults` 引用形式出现在回答流中。客户端若要自行声明 `web_search`（type 或 function name），网关不会重复注入。
+
 ### 数据文件
 
 | 变量 | 说明 |

--- a/internal/chathub/client.go
+++ b/internal/chathub/client.go
@@ -315,7 +315,9 @@ func (c *Client) chatWithHandlers(ctx context.Context, acc Account, req Request,
 							reasoningBuf.WriteString(ev.Text)
 						}
 						ev.Raw = eventRaw(arg)
-						if ev.Kind != "text" && onEvent != nil {
+						// SearchResults frames carry live citations; surface them to
+						// handlers even though they are classified as text.
+						if (ev.Kind != "text" || ev.ContentType == "SearchResults") && onEvent != nil {
 							if err := onEvent(ev); err != nil {
 								return Result{}, err
 							}

--- a/internal/chathub/stream_events.go
+++ b/internal/chathub/stream_events.go
@@ -1,6 +1,9 @@
 package chathub
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // classifyUpdateMessages converts a ChatHub messages array into protocol-neutral
 // events. It deliberately does not infer tools from ordinary prose.
@@ -17,8 +20,16 @@ func classifyUpdateMessages(messages []any) []StreamEvent {
 		origin, _ := m["contentOrigin"].(string)
 		cot, _ := m["addToChainOfThought"].(bool)
 		kind := "text"
-		if mt == "Progress" || ct == "SearchResults" || ct == "Code" || ct == "ToolCall" {
+		if mt == "Progress" || ct == "Code" || ct == "ToolCall" {
 			kind = "progress"
+		}
+		if ct == "SearchResults" {
+			// Surface search progress as a visible citation instead of a
+			// progress frame that gateway handlers silently drop.
+			kind = "text"
+			if text != "" && !strings.HasPrefix(text, "\U0001F50E ") {
+				text = "\U0001F50E " + text
+			}
 		}
 		// ChatHub marks the multi-step reasoning transcript (ChainOfThought cards)
 		// via contentOrigin and addToChainOfThought. Expose it separately so the
@@ -27,7 +38,7 @@ func classifyUpdateMessages(messages []any) []StreamEvent {
 			kind = "reasoning"
 		}
 		name, args := extractToolFields(m)
-		if name != "" && len(args) > 0 {
+		if name != "" && len(args) > 0 && WebSearchUsable(name, args) {
 			kind = "tool"
 		}
 		if text == "" && kind == "text" {
@@ -76,7 +87,7 @@ func extractToolEvents(v any, seen map[string]bool) []StreamEvent {
 			}
 		case map[string]any:
 			name, args := extractToolFields(z)
-			if name != "" && len(args) > 0 {
+			if name != "" && len(args) > 0 && WebSearchUsable(name, args) {
 				key := name + "|" + string(args)
 				if !seen[key] {
 					seen[key] = true
@@ -90,4 +101,27 @@ func extractToolEvents(v any, seen map[string]bool) []StreamEvent {
 	}
 	walk(v)
 	return out
+}
+
+// WebSearchUsable rejects web_search invocations without a usable query.
+// Copilot occasionally emits {"type":"web_search","name":"web_search",
+// "input":{}} which would surface as a broken empty tool_use to the client.
+// All other tool names are always usable.
+func WebSearchUsable(name string, args json.RawMessage) bool {
+	if name != "web_search" {
+		return true
+	}
+	var m map[string]any
+	if json.Unmarshal(args, &m) != nil {
+		return false
+	}
+	if len(m) == 0 {
+		return false
+	}
+	for _, k := range []string{"query", "q", "search", "searchQuery", "text", "input", "prompt"} {
+		if s, ok := m[k].(string); ok && strings.TrimSpace(s) != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/chathub/stream_events_test.go
+++ b/internal/chathub/stream_events_test.go
@@ -1,6 +1,10 @@
 package chathub
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestClassifyUpdateMessages(t *testing.T) {
 	got := classifyUpdateMessages([]any{
@@ -8,11 +12,63 @@ func TestClassifyUpdateMessages(t *testing.T) {
 		map[string]any{"messageType": "Progress", "contentType": "SearchResults", "text": "正在搜索"},
 		map[string]any{"toolName": "web_search", "arguments": map[string]any{"query": "golang"}},
 	})
-	if len(got) != 3 || got[0].Kind != "text" || got[1].Kind != "progress" || got[2].Kind != "tool" {
+	if len(got) != 3 || got[0].Kind != "text" || got[1].Kind != "text" || got[2].Kind != "tool" {
 		t.Fatalf("unexpected events: %#v", got)
+	}
+	// SearchResults surfaces as a visible citation, not a dropped progress frame.
+	if got[1].ContentType != "SearchResults" || !strings.HasPrefix(got[1].Text, "\U0001F50E ") {
+		t.Fatalf("SearchResults should surface as a citation: %#v", got[1])
 	}
 	if got[2].ToolName != "web_search" || len(got[2].Arguments) == 0 {
 		t.Fatalf("tool fields missing: %#v", got[2])
+	}
+}
+
+func TestClassifyUpdateMessagesDropsEmptyWebSearch(t *testing.T) {
+	got := classifyUpdateMessages([]any{
+		map[string]any{"messageType": "Progress", "contentType": "ToolCall", "toolName": "web_search", "arguments": map[string]any{}},
+		map[string]any{"toolName": "web_search", "arguments": map[string]any{"query": "ok"}},
+	})
+	if len(got) != 2 || got[0].Kind == "tool" || got[1].Kind != "tool" || got[1].ToolName != "web_search" {
+		t.Fatalf("empty web_search must not become a tool call, got %#v", got)
+	}
+}
+
+func TestExtractToolEventsDropsEmptyWebSearch(t *testing.T) {
+	seen := map[string]bool{}
+	got := extractToolEvents([]any{
+		map[string]any{"plugin": map[string]any{"functionName": "web_search", "functionArguments": map[string]any{}}},
+		map[string]any{"plugin": map[string]any{"functionName": "web_search", "functionArguments": map[string]any{"query": "x"}}},
+	}, seen)
+	if len(got) != 1 || got[0].ToolName != "web_search" || len(got[0].Arguments) == 0 {
+		t.Fatalf("empty web_search must be dropped, got %#v", got)
+	}
+}
+
+func TestWebSearchUsable(t *testing.T) {
+	cases := []struct {
+		name string
+		tool string
+		args map[string]any
+		want bool
+	}{
+		{"non web_search always usable", "other_tool", map[string]any{"x": 1}, true},
+		{"web_search with query", "web_search", map[string]any{"query": "golang"}, true},
+		{"web_search with q", "web_search", map[string]any{"q": "golang"}, true},
+		{"web_search empty object", "web_search", map[string]any{}, false},
+		{"web_search blank query", "web_search", map[string]any{"query": "  "}, false},
+		{"web_search null", "web_search", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var b []byte
+			if tc.args != nil {
+				b, _ = json.Marshal(tc.args)
+			}
+			if got := WebSearchUsable(tc.tool, b); got != tc.want {
+				t.Fatalf("WebSearchUsable = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/chathub/tool_protocol.go
+++ b/internal/chathub/tool_protocol.go
@@ -15,11 +15,19 @@ func toolProtocolPrompt(text string, tools []Tool, choice any) string {
 	}
 	var defs []string
 	for _, t := range tools {
+		if strings.EqualFold(t.Type, "web_search") {
+			defs = append(defs, webSearchDecl)
+			continue
+		}
 		var f struct {
 			Name, Description string
 			Parameters        json.RawMessage `json:"parameters"`
 		}
 		if json.Unmarshal(t.Function, &f) != nil || f.Name == "" {
+			continue
+		}
+		if strings.EqualFold(f.Name, "web_search") {
+			defs = append(defs, webSearchDecl)
 			continue
 		}
 		params := strings.TrimSpace(string(f.Parameters))
@@ -41,3 +49,7 @@ When the user's request requires a tool, call it by emitting ONLY one fenced blo
 User request:
 %s`, strings.Join(defs, "\n\n"), text)
 }
+
+// webSearchDecl lets the upstream model know web_search exists and how to
+// call it, even when the client sent no JSON schema for it.
+const webSearchDecl = "web_search \u2014 Search the web for current, up-to-date information.\n```web_search\n{\"query\": \"<search text>\"}\n```"

--- a/internal/chathub/tools.go
+++ b/internal/chathub/tools.go
@@ -1,11 +1,21 @@
 package chathub
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 type Tool struct {
 	Type     string          `json:"type"`
 	Function json.RawMessage `json:"function,omitempty"`
 }
+
+// webSearchPlugin mirrors the plugins payload the M365 web UI sends when the
+// web search toggle is on (PlugInInfo: [{"Id":"BingWebSearch","Source":
+// "BuiltIn"}]). Copilot runs the Bing search server-side and returns
+// grounded answers with SearchResults citations; a Client-side duplicate
+// would only surface a tool call the caller cannot execute.
+var webSearchPlugin = map[string]any{"Id": "BingWebSearch", "Source": "BuiltIn"}
 
 func clientPlugins(tools []Tool, mcpServerURL string) []any {
 	plugins := make([]any, 0, len(tools)+1)
@@ -20,12 +30,20 @@ func clientPlugins(tools []Tool, mcpServerURL string) []any {
 		})
 	}
 	for _, t := range tools {
+		if strings.EqualFold(t.Type, "web_search") {
+			plugins = append(plugins, webSearchPlugin)
+			continue
+		}
 		var f struct {
 			Name        string          `json:"name"`
 			Description string          `json:"description"`
 			Parameters  json.RawMessage `json:"parameters"`
 		}
 		if json.Unmarshal(t.Function, &f) != nil || f.Name == "" {
+			continue
+		}
+		if strings.EqualFold(f.Name, "web_search") {
+			plugins = append(plugins, webSearchPlugin)
 			continue
 		}
 		plugins = append(plugins, map[string]any{"Id": f.Name, "Source": "Client", "Description": f.Description, "Parameters": f.Parameters})

--- a/internal/chathub/tools_test.go
+++ b/internal/chathub/tools_test.go
@@ -1,0 +1,55 @@
+package chathub
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClientPluginsWebSearchBuiltIn(t *testing.T) {
+	// web_search must be declared exactly like the web UI toggle does:
+	// {"Id":"BingWebSearch","Source":"BuiltIn"}, so Copilot searches
+	// server-side instead of surfacing an unexecutable client tool call.
+	byType := Tool{Type: "web_search", Function: nil}
+	byName := Tool{Type: "function", Function: json.RawMessage(`{"name":"web_search","description":"search","parameters":null}`)}
+	for _, tc := range []struct {
+		name  string
+		tools []Tool
+	}{{"by type", []Tool{byType}}, {"by name", []Tool{byName}}} {
+		t.Run(tc.name, func(t *testing.T) {
+			plugins := clientPlugins(tc.tools, "")
+			if len(plugins) != 1 {
+				t.Fatalf("plugins = %#v", plugins)
+			}
+			m, _ := plugins[0].(map[string]any)
+			if m["Id"] != "BingWebSearch" || m["Source"] != "BuiltIn" {
+				t.Fatalf("web_search plugin = %#v, want BingWebSearch/BuiltIn", m)
+			}
+		})
+	}
+}
+
+func TestClientPluginsOtherToolsStillClient(t *testing.T) {
+	fn := Tool{Type: "function", Function: json.RawMessage(`{"name":"get_weather","description":"weather","parameters":{"type":"object"}}`)}
+	plugins := clientPlugins([]Tool{fn}, "")
+	if len(plugins) != 1 {
+		t.Fatalf("plugins = %#v", plugins)
+	}
+	m, _ := plugins[0].(map[string]any)
+	if m["Id"] != "get_weather" || m["Source"] != "Client" {
+		t.Fatalf("ordinary tool plugin = %#v, want get_weather/Client", m)
+	}
+}
+
+func TestToolProtocolPromptDeclaresWebSearch(t *testing.T) {
+	ws := Tool{Type: "web_search", Function: nil}
+	prompt := toolProtocolPrompt("Find the latest price.", []Tool{ws}, "auto")
+	if !strings.Contains(prompt, "web_search") || !strings.Contains(prompt, `"query"`) {
+		t.Fatalf("web_search declaration missing from prompt:\n%s", prompt)
+	}
+	fn := Tool{Type: "function", Function: json.RawMessage(`{"name":"get_weather","description":"weather","parameters":{"type":"object"}}`)}
+	prompt = toolProtocolPrompt("What is the weather?", []Tool{fn}, "auto")
+	if !strings.Contains(prompt, "get_weather") || strings.Contains(prompt, "web_search") {
+		t.Fatalf("function tool rendering broken:\n%s", prompt)
+	}
+}

--- a/internal/web/native_tools.go
+++ b/internal/web/native_tools.go
@@ -54,6 +54,9 @@ func walkNative(v any, allowed map[string]bool, out *[]detectedToolCall) {
 			}
 			if a != nil {
 				b, _ := json.Marshal(a)
+				if !chathub.WebSearchUsable(name, b) {
+					return
+				}
 				h := sha256.Sum256([]byte(fmt.Sprintf("%s:%s", name, b)))
 				*out = append(*out, detectedToolCall{ID: "call_" + hex.EncodeToString(h[:8]), Name: name, Arguments: b})
 				return

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -822,17 +822,17 @@ type oaiReq struct {
 	Messages       []oaiMsg        `json:"messages"`
 	Stream         bool            `json:"stream"`
 	// optional account routing
-	User           string               `json:"user"`
-	AccountID      string               `json:"accountId"`
-	ConversationID string               `json:"conversation_id"`
-	SessionID      string               `json:"session_id"`
-	SessionKey     string               `json:"session_key"`
+	User           string `json:"user"`
+	AccountID      string `json:"accountId"`
+	ConversationID string `json:"conversation_id"`
+	SessionID      string `json:"session_id"`
+	SessionKey     string `json:"session_key"`
 	// CamelCase aliases mirroring the response metadata fields; clients echo
 	// m365.conversationId / m365.sessionId back verbatim.
-	ConversationIDC string `json:"conversationId,omitempty"`
-	SessionIDC      string `json:"sessionId,omitempty"`
-	Attachments    []chathub.Attachment `json:"attachments,omitempty"`
-	Tools          []chathub.Tool       `json:"tools,omitempty"`
+	ConversationIDC string               `json:"conversationId,omitempty"`
+	SessionIDC      string               `json:"sessionId,omitempty"`
+	Attachments     []chathub.Attachment `json:"attachments,omitempty"`
+	Tools           []chathub.Tool       `json:"tools,omitempty"`
 	// Legacy OpenAI-compatible clients still send functions/function_call.
 	Functions       []json.RawMessage `json:"functions,omitempty"`
 	ToolChoice      any               `json:"tool_choice,omitempty"`
@@ -912,6 +912,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	normalizeLegacyTools(&body)
+	ensureWebSearchEnabled(&body)
 	body.ConversationID = firstNonEmpty(body.ConversationID, body.ConversationIDC)
 	body.SessionID = firstNonEmpty(body.SessionID, body.SessionIDC)
 	log.Printf("[req-trace] id=%s stage=body_parsed messages=%d tools=%d choice=%s raw_bytes=%d", requestID, len(body.Messages), len(body.Tools), normalizedToolChoiceMode(body.ToolChoice), len(raw))
@@ -1003,6 +1004,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		_ = json.Unmarshal(tool.Function, &f)
 		toolMaps = append(toolMaps, map[string]any{"type": tool.Type, "function": f})
 	}
+	routeMaps := routeableTools(toolMaps)
 	if body.ToolChoice == nil && len(toolMaps) > 0 {
 		body.ToolChoice = "auto"
 	}
@@ -1019,12 +1021,12 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 	// path forwards ordinary upstream text deltas immediately; tool routing for
 	// non-streaming requests remains below until the event-level tool protocol
 	// is available end-to-end.
-	if planningMode == "router" && body.Stream && len(toolMaps) > 0 && fmt.Sprint(body.ToolChoice) != "none" {
+	if planningMode == "router" && body.Stream && len(routeMaps) > 0 && fmt.Sprint(body.ToolChoice) != "none" {
 		// Preserve the existing validated tool router for streaming tool turns.
 		// Only fall through to text streaming when the router explicitly selects
 		// no tool; this prevents a natural-language preamble from becoming a
 		// completed assistant turn with the actual call lost.
-		routePrompt := modelToolRouterPrompt(prompt+"\n"+ledger.RouterContext(), toolMaps, body.ToolChoice)
+		routePrompt := modelToolRouterPrompt(prompt+"\n"+ledger.RouterContext(), routeMaps, body.ToolChoice)
 		log.Printf("[req-trace] id=%s stage=router_start prompt_len=%d", requestID, len(routePrompt))
 		routeRes, routeErr := s.chat.Chat(ctx, account, chathub.Request{Text: routePrompt, Tone: tone, Attachments: body.Attachments})
 		log.Printf("[req-trace] id=%s stage=router_return elapsed_ms=%d err=%t", requestID, time.Since(startedAt).Milliseconds(), routeErr != nil)
@@ -1038,7 +1040,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "tool router: "+routeErr.Error(), http.StatusBadGateway)
 			return
 		}
-		calls, parsed := parseModelToolDecision(routeRes.Text, toolMaps, body.ToolChoice)
+		calls, parsed := parseModelToolDecision(routeRes.Text, routeMaps, body.ToolChoice)
 		calls = filterCompletedCalls(calls, ledger)
 		if !parsed {
 			repairRes, repairErr := s.chat.Chat(ctx, account, chathub.Request{Text: `Repair this tool routing output into JSON only with shape {"calls":[{"name":"function_name","arguments":{}}]}. Use {"calls":[]} if no tool is needed. OUTPUT:\n` + compactToolResult(routeRes.Text, 6000), Tone: tone, Attachments: body.Attachments})
@@ -1046,7 +1048,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 				s.dropTransientConversation(repairRes.ConversationID)
 			}
 			if repairErr == nil {
-				calls, parsed = parseModelToolDecision(repairRes.Text, toolMaps, body.ToolChoice)
+				calls, parsed = parseModelToolDecision(repairRes.Text, routeMaps, body.ToolChoice)
 				calls = filterCompletedCalls(calls, ledger)
 			}
 		}
@@ -1183,19 +1185,19 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 	}
 	// Ask the upstream model to select and validate the next tool. The gateway
 	// remains tool-agnostic; it only validates and serializes the decision.
-	if planningMode == "router" && len(toolMaps) > 0 && fmt.Sprint(body.ToolChoice) != "none" {
-		routePrompt := modelToolRouterPrompt(prompt+"\n"+ledger.RouterContext(), toolMaps, body.ToolChoice)
+	if planningMode == "router" && len(routeMaps) > 0 && fmt.Sprint(body.ToolChoice) != "none" {
+		routePrompt := modelToolRouterPrompt(prompt+"\n"+ledger.RouterContext(), routeMaps, body.ToolChoice)
 		routeRes, routeErr := s.chat.Chat(ctx, account, chathub.Request{Text: routePrompt, Tone: tone, Attachments: body.Attachments})
 		if routeErr != nil {
 			http.Error(w, "tool router: "+routeErr.Error(), http.StatusBadGateway)
 			return
 		}
-		calls, parsed := parseModelToolDecision(routeRes.Text, toolMaps, body.ToolChoice)
+		calls, parsed := parseModelToolDecision(routeRes.Text, routeMaps, body.ToolChoice)
 		if !parsed {
 			repairRes, repairErr := s.chat.Chat(ctx, account, chathub.Request{Text: `Repair this tool routing output into JSON only with shape {"calls":[{"name":"function_name","arguments":{}}]}. Do not invent calls; use {"calls":[]} if unrecoverable. OUTPUT:
 ` + compactToolResult(routeRes.Text, 6000), Tone: tone, Attachments: body.Attachments})
 			if repairErr == nil {
-				calls, parsed = parseModelToolDecision(repairRes.Text, toolMaps, body.ToolChoice)
+				calls, parsed = parseModelToolDecision(repairRes.Text, routeMaps, body.ToolChoice)
 			}
 			if !parsed {
 				http.Error(w, "model returned an invalid tool routing decision", http.StatusBadGateway)
@@ -1212,13 +1214,13 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if fmt.Sprint(body.ToolChoice) == "required" {
-			defs, _ := json.Marshal(toolMaps)
+			defs, _ := json.Marshal(routeMaps)
 			retryText := `Select at least one required next tool call from FUNCTION_DEFINITIONS. Validate every argument against its schema. Return JSON only as {"calls":[{"name":"function_name","arguments":{}}]}.
 APPLICATION_REQUEST_AND_EVIDENCE:
 ` + prompt + "\n" + ledger.RouterContext() + "\nFUNCTION_DEFINITIONS:\n" + string(defs)
 			retryRes, retryErr := s.chat.Chat(ctx, account, chathub.Request{Text: retryText, Tone: tone, Attachments: body.Attachments})
 			if retryErr == nil {
-				calls, parsed = parseModelToolDecision(retryRes.Text, toolMaps, body.ToolChoice)
+				calls, parsed = parseModelToolDecision(retryRes.Text, routeMaps, body.ToolChoice)
 				calls = filterCompletedCalls(calls, ledger)
 				if parsed && len(calls) > 0 {
 					scope := fmt.Sprintf("%d:%v:required-retry", len(body.Messages), completedCallIDs(ledger))
@@ -1353,15 +1355,15 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 	}
 	// Recover natural-language tool intent when native mode emits no
 	// structured ChatHub tool event. Plain text remains a zero-call result.
-	if planningMode == "native" && len(toolMaps) > 0 && fmt.Sprint(body.ToolChoice) != "none" {
-		routePrompt := modelToolRouterPrompt(prompt+"\n"+ledger.RouterContext(), toolMaps, body.ToolChoice)
+	if planningMode == "native" && len(routeMaps) > 0 && fmt.Sprint(body.ToolChoice) != "none" {
+		routePrompt := modelToolRouterPrompt(prompt+"\n"+ledger.RouterContext(), routeMaps, body.ToolChoice)
 		routeRes, routeErr := s.chat.Chat(ctx, account, chathub.Request{Text: routePrompt, Tone: tone, Attachments: body.Attachments})
 		if routeErr == nil {
-			calls, parsed := parseModelToolDecision(routeRes.Text, toolMaps, body.ToolChoice)
+			calls, parsed := parseModelToolDecision(routeRes.Text, routeMaps, body.ToolChoice)
 			if !parsed {
 				repairRes, repairErr := s.chat.Chat(ctx, account, chathub.Request{Text: `Repair this tool routing output into JSON only with shape {"calls":[{"name":"function_name","arguments":{}}]}. Use {"calls":[]} if no tool is needed. OUTPUT:\n` + compactToolResult(routeRes.Text, 6000), Tone: tone, Attachments: body.Attachments})
 				if repairErr == nil {
-					calls, parsed = parseModelToolDecision(repairRes.Text, toolMaps, body.ToolChoice)
+					calls, parsed = parseModelToolDecision(repairRes.Text, routeMaps, body.ToolChoice)
 				}
 			}
 			if parsed && len(calls) > 0 {

--- a/internal/web/toolloop.go
+++ b/internal/web/toolloop.go
@@ -15,6 +15,33 @@ type detectedToolCall struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
+// isWebSearchTool reports whether a tool map is the web_search declaration.
+// Web search is a Copilot built-in (BingWebSearch) performed server-side, so
+// it must not enter the router decision; the answer stream handles it.
+func isWebSearchTool(t map[string]any) bool {
+	if s, _ := t["type"].(string); strings.EqualFold(s, "web_search") {
+		return true
+	}
+	if f, ok := t["function"].(map[string]any); ok {
+		if n, _ := f["name"].(string); strings.EqualFold(n, "web_search") {
+			return true
+		}
+	}
+	return false
+}
+
+// routeableTools drops web_search from the router decision set while keeping
+// every declared tool visible to the streaming JSON guard and prompt.
+func routeableTools(tools []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		if !isWebSearchTool(t) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 func toolType(name string, tools []map[string]any) string {
 	for _, t := range tools {
 		f, _ := t["function"].(map[string]any)

--- a/internal/web/websearch_enable.go
+++ b/internal/web/websearch_enable.go
@@ -1,0 +1,41 @@
+package web
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"m365-copilot2api/internal/chathub"
+)
+
+// webSearchDisabled reports whether M365_ENABLE_WEB_SEARCH turns off the
+// automatic web_search declaration. Web search is enabled by default and is
+// only disabled by an explicit 0/false/off/no value.
+func webSearchDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("M365_ENABLE_WEB_SEARCH"))) {
+	case "0", "false", "off", "no":
+		return true
+	}
+	return false
+}
+
+// ensureWebSearchEnabled injects the built-in web_search tool declaration
+// when the client did not already declare it, so ChatHub registers the
+// BingWebSearch built-in and can ground answers in live search results.
+// Disable with M365_ENABLE_WEB_SEARCH=0 (or false/off).
+func ensureWebSearchEnabled(body *oaiReq) {
+	if webSearchDisabled() {
+		return
+	}
+	for _, t := range body.Tools {
+		isWebSearchType := strings.EqualFold(t.Type, "web_search")
+		var f struct{ Name string }
+		if json.Unmarshal(t.Function, &f) == nil && strings.EqualFold(f.Name, "web_search") {
+			isWebSearchType = true
+		}
+		if isWebSearchType {
+			return // client already declared it
+		}
+	}
+	body.Tools = append(body.Tools, chathub.Tool{Type: "web_search"})
+}

--- a/internal/web/websearch_enable_test.go
+++ b/internal/web/websearch_enable_test.go
@@ -1,0 +1,97 @@
+package web
+
+import (
+	"encoding/json"
+	"testing"
+
+	"m365-copilot2api/internal/chathub"
+)
+
+func TestEnsureWebSearchEnabledDefaultOn(t *testing.T) {
+	t.Setenv("M365_ENABLE_WEB_SEARCH", "")
+	body := &oaiReq{}
+	ensureWebSearchEnabled(body)
+	if len(body.Tools) != 1 || body.Tools[0].Type != "web_search" || body.Tools[0].Function != nil {
+		t.Fatalf("expected exactly one injected web_search declaration, got %+v", body.Tools)
+	}
+}
+
+func TestEnsureWebSearchEnabledNoDuplicateByType(t *testing.T) {
+	t.Setenv("M365_ENABLE_WEB_SEARCH", "")
+	body := &oaiReq{Tools: []chathub.Tool{{Type: "web_search"}}}
+	ensureWebSearchEnabled(body)
+	if len(body.Tools) != 1 {
+		t.Fatalf("web_search must not be injected twice, got %+v", body.Tools)
+	}
+}
+
+func TestEnsureWebSearchEnabledNoDuplicateByFunctionName(t *testing.T) {
+	t.Setenv("M365_ENABLE_WEB_SEARCH", "")
+	body := &oaiReq{Tools: []chathub.Tool{{Type: "function", Function: json.RawMessage(`{"name":"web_search"}`)}}}
+	ensureWebSearchEnabled(body)
+	if len(body.Tools) != 1 {
+		t.Fatalf("web_search must not be injected when declared by function name, got %+v", body.Tools)
+	}
+}
+
+func TestEnsureWebSearchEnabledAppendsToOtherTools(t *testing.T) {
+	t.Setenv("M365_ENABLE_WEB_SEARCH", "")
+	body := &oaiReq{Tools: []chathub.Tool{{Type: "function", Function: json.RawMessage(`{"name":"get_weather"}`)}}}
+	ensureWebSearchEnabled(body)
+	if len(body.Tools) != 2 || body.Tools[1].Type != "web_search" {
+		t.Fatalf("expected web_search appended after get_weather, got %+v", body.Tools)
+	}
+}
+
+func TestEnsureWebSearchEnabledDisabledValues(t *testing.T) {
+	for _, v := range []string{"0", "false", "off", "no", "FALSE", "Off"} {
+		t.Setenv("M365_ENABLE_WEB_SEARCH", v)
+		body := &oaiReq{}
+		ensureWebSearchEnabled(body)
+		if len(body.Tools) != 0 {
+			t.Fatalf("M365_ENABLE_WEB_SEARCH=%s must not inject, got %+v", v, body.Tools)
+		}
+	}
+}
+
+// The injected declaration must never activate the tool router: web_search
+// is a Copilot built-in excluded from the router decision set.
+func TestInjectedWebSearchStaysOutOfRouter(t *testing.T) {
+	t.Setenv("M365_ENABLE_WEB_SEARCH", "")
+	body := &oaiReq{}
+	ensureWebSearchEnabled(body)
+	toolMaps := make([]map[string]any, 0, len(body.Tools))
+	for _, tool := range body.Tools {
+		var f map[string]any
+		_ = json.Unmarshal(tool.Function, &f)
+		toolMaps = append(toolMaps, map[string]any{"type": tool.Type, "function": f})
+	}
+	if routes := routeableTools(toolMaps); len(routes) != 0 {
+		t.Fatalf("web_search must be excluded from router decisions, got %+v", routes)
+	}
+	if !isWebSearchTool(toolMaps[0]) {
+		t.Fatal("injected web_search must be recognized as web search tool")
+	}
+}
+
+func TestRouteableToolsKeepsClientFunctions(t *testing.T) {
+	body := &oaiReq{
+		Tools: []chathub.Tool{
+			{Type: "function", Function: json.RawMessage(`{"name":"get_weather"}`)},
+			{Type: "web_search"},
+		},
+	}
+	toolMaps := make([]map[string]any, 0, len(body.Tools))
+	for _, tool := range body.Tools {
+		var f map[string]any
+		_ = json.Unmarshal(tool.Function, &f)
+		toolMaps = append(toolMaps, map[string]any{"type": tool.Type, "function": f})
+	}
+	routes := routeableTools(toolMaps)
+	if len(routes) != 1 {
+		t.Fatalf("expected get_weather only in router set, got %+v", routes)
+	}
+	if f, _ := routes[0]["function"].(map[string]any); f["name"] != "get_weather" {
+		t.Fatalf("routeableTools kept the wrong tool: %+v", routes)
+	}
+}


### PR DESCRIPTION
Fixes #10

## 背景

经 OpenAI / Anthropic 兼容客户端调用网关，`/v1/chat/completions` 与 `/v1/messages` 均**无法联网搜索作答**——模型报告"没有可用的搜索工具"。M365 网页版启用联网搜索时发送 `{"PlugInInfo":[{"Id":"BingWebSearch","Source":"BuiltIn"}]}`；而网关 `clientPlugins` 只把客户端声明的工具映射为 `Client` 插件，客户端不显式声明 `web_search` 时 ChatHub 永远收不到内建搜索插件。

## 变更内容

- `internal/web/websearch_enable.go`（新增）：默认向每个对话/消息请求**自动注入 `web_search` 声明**（客户端已声明或 `M365_ENABLE_WEB_SEARCH=0` 时跳过，默认开启）
- `internal/chathub/tools.go`：`web_search` 映射为 `BingWebSearch/BuiltIn` **内建插件**（而非无法执行的 Client 插件）
- `internal/chathub/tool_protocol.go`：工具提示中声明 `web_search`（客户端未提供 schema 时也能声明）
- `internal/chathub/stream_events.go` + `client.go`：`SearchResults` 帧以**可见引用文本**输出（不再被 progress 事件静默丢弃）；`WebSearchUsable` 过滤 Copilot 偶发的空参数 `web_search` 调用
- `internal/web/server.go` + `toolloop.go`：`web_search` 从**工具路由决策集中排除**（OpenAI 与 Anthropic 路径均汇聚到 `openaiChat`），注入的声明不会变成客户端无法执行的 `tool_calls`/`tool_use`
- `internal/web/native_tools.go`：native 规划器同样丢弃空 `web_search`
- README：新增 `M365_ENABLE_WEB_SEARCH` 配置说明

## 测试

- 新增：注入默认/去重/禁用值、插件映射（`BingWebSearch/BuiltIn`）、路由排除、`WebSearchUsable`、`classifyUpdateMessages`/`extractToolEvents` 空调用过滤
- `go vet ./...` 与 `go test ./...` 全部通过（所有包）

## 备注

- `web_search` 作为客户端自声明工具（`type` 或 function `name` 形式）仍然可用，已声明时不会重复注入
- 部署时可通过 `M365_ENABLE_WEB_SEARCH=0` 关闭，完全保持原有行为

---

> 📌 **署名说明**：该问题由 AI 编码助手 **deepseek-v4-flash**）在网关部署切换后的真实流量探测中发现并定位根因，本 PR 由同一代理实现并提交。