### PR TITLE
feat(auth): isolate device-code OAuth configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,13 @@ M365_ACCOUNT_DEFAULT_CONCURRENCY=8
 # Optional public identity policy. Disabled by default; set true only for the
 # Microsoft gateway channel that needs neutralized public identity output.
 M365_PUBLIC_IDENTITY_POLICY=false
+
+# Browser PKCE and Device Code OAuth can use independent app registrations.
+# Legacy M365_CLIENT_ID / M365_AUTHORITY / M365_SCOPE remain fallbacks.
+# M365_BROWSER_CLIENT_ID=your-browser-application-client-id
+# M365_BROWSER_AUTHORITY=https://login.microsoftonline.com/common
+# M365_BROWSER_SCOPE=openid profile offline_access
+# M365_BROWSER_REDIRECT_URI=https://login.microsoftonline.com/common/oauth2/nativeclient
+# M365_DEVICE_CLIENT_ID=d3590ed6-52b3-4102-aeff-aad2292ab01c
+# M365_DEVICE_AUTHORITY=https://login.microsoftonline.com/common
+# M365_DEVICE_SCOPE=openid profile offline_access

--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ python manage.py stop     # 停止服务
 | `M365_PROXY_POOL` | 空 | 代理列表（逗号或换行分隔，支持 http / https / socks5） |
 | `M365_PROXY_INSECURE_TLS` | — | 信任自签代理证书（`1` / `true`） |
 | `M365_PROXY_HEALTH_URL` | 默认探测地址 | 代理健康检查目标 |
-| `M365_CLIENT_ID` | 内置 | Azure 应用 Client ID |
-| `M365_AUTHORITY` / `M365_REDIRECT_URI` / `M365_SCOPE` | 内置 | OAuth 端点自定义覆盖 |
+| `M365_BROWSER_CLIENT_ID` / `M365_BROWSER_AUTHORITY` / `M365_BROWSER_REDIRECT_URI` / `M365_BROWSER_SCOPE` | 内置 | 浏览器 PKCE 的 OAuth 配置 |
+| `M365_DEVICE_CLIENT_ID` / `M365_DEVICE_AUTHORITY` / `M365_DEVICE_SCOPE` | 内置 | Device Code 的 OAuth 配置 |
+| `M365_CLIENT_ID` / `M365_AUTHORITY` / `M365_REDIRECT_URI` / `M365_SCOPE` | 内置 | 兼容旧配置；流程专用变量未设置时作为回退 |
 
 ### 数据文件
 

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -12,6 +12,9 @@ const DefaultRedirectURI = "https://login.microsoftonline.com/common/oauth2/nati
 const DefaultScope = "openid profile offline_access https://substrate.office.com/sydney/M365Chat.Read https://substrate.office.com/sydney/sydney.readwrite"
 
 func ClientID() string {
+	if v := os.Getenv("M365_BROWSER_CLIENT_ID"); v != "" {
+		return v
+	}
 	if v := os.Getenv("M365_CLIENT_ID"); v != "" {
 		return v
 	}
@@ -19,6 +22,9 @@ func ClientID() string {
 }
 
 func Authority() string {
+	if v := os.Getenv("M365_BROWSER_AUTHORITY"); v != "" {
+		return v
+	}
 	if v := os.Getenv("M365_AUTHORITY"); v != "" {
 		return v
 	}
@@ -26,6 +32,9 @@ func Authority() string {
 }
 
 func RedirectURI() string {
+	if v := os.Getenv("M365_BROWSER_REDIRECT_URI"); v != "" {
+		return v
+	}
 	if v := os.Getenv("M365_REDIRECT_URI"); v != "" {
 		return v
 	}
@@ -33,6 +42,39 @@ func RedirectURI() string {
 }
 
 func Scope() string {
+	if v := os.Getenv("M365_BROWSER_SCOPE"); v != "" {
+		return v
+	}
+	if v := os.Getenv("M365_SCOPE"); v != "" {
+		return v
+	}
+	return DefaultScope
+}
+
+func DeviceClientID() string {
+	if v := os.Getenv("M365_DEVICE_CLIENT_ID"); v != "" {
+		return v
+	}
+	if v := os.Getenv("M365_CLIENT_ID"); v != "" {
+		return v
+	}
+	return FOCIClientID
+}
+
+func DeviceAuthority() string {
+	if v := os.Getenv("M365_DEVICE_AUTHORITY"); v != "" {
+		return v
+	}
+	if v := os.Getenv("M365_AUTHORITY"); v != "" {
+		return v
+	}
+	return DefaultAuthority
+}
+
+func DeviceScope() string {
+	if v := os.Getenv("M365_DEVICE_SCOPE"); v != "" {
+		return v
+	}
 	if v := os.Getenv("M365_SCOPE"); v != "" {
 		return v
 	}
@@ -57,5 +99,12 @@ func DeviceCodeEndpoint() string {
 	if v := os.Getenv("M365_DEVICE_ENDPOINT"); v != "" {
 		return v
 	}
-	return Authority() + "/oauth2/v2.0/devicecode"
+	return DeviceAuthority() + "/oauth2/v2.0/devicecode"
+}
+
+func DeviceTokenEndpoint() string {
+	if v := os.Getenv("M365_DEVICE_TOKEN_ENDPOINT"); v != "" {
+		return v
+	}
+	return DeviceAuthority() + "/oauth2/v2.0/token"
 }

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -42,3 +42,44 @@ func TestAuthorityOverride(t *testing.T) {
 		t.Fatalf("Authority() = %q", got)
 	}
 }
+
+func TestBrowserAndDeviceConfigurationAreIsolated(t *testing.T) {
+	t.Setenv("M365_BROWSER_CLIENT_ID", "browser-client")
+	t.Setenv("M365_BROWSER_AUTHORITY", "https://login.microsoftonline.com/organizations")
+	t.Setenv("M365_BROWSER_SCOPE", "browser-scope")
+	t.Setenv("M365_BROWSER_REDIRECT_URI", "http://127.0.0.1:4141/api/auth/callback")
+	t.Setenv("M365_DEVICE_CLIENT_ID", "device-client")
+	t.Setenv("M365_DEVICE_AUTHORITY", "https://login.microsoftonline.com/consumers")
+	t.Setenv("M365_DEVICE_SCOPE", "device-scope")
+
+	if ClientID() != "browser-client" || Authority() != "https://login.microsoftonline.com/organizations" || Scope() != "browser-scope" {
+		t.Fatal("browser OAuth configuration was not isolated")
+	}
+	if DeviceClientID() != "device-client" || DeviceAuthority() != "https://login.microsoftonline.com/consumers" || DeviceScope() != "device-scope" {
+		t.Fatal("device-code configuration was not isolated")
+	}
+	if got := DeviceTokenEndpoint(); got != "https://login.microsoftonline.com/consumers/oauth2/v2.0/token" {
+		t.Fatalf("DeviceTokenEndpoint() = %q", got)
+	}
+}
+
+func TestLegacyOAuthConfigurationRemainsCompatible(t *testing.T) {
+	t.Setenv("M365_BROWSER_CLIENT_ID", "")
+	t.Setenv("M365_BROWSER_AUTHORITY", "")
+	t.Setenv("M365_BROWSER_SCOPE", "")
+	t.Setenv("M365_BROWSER_REDIRECT_URI", "")
+	t.Setenv("M365_DEVICE_CLIENT_ID", "")
+	t.Setenv("M365_DEVICE_AUTHORITY", "")
+	t.Setenv("M365_DEVICE_SCOPE", "")
+	t.Setenv("M365_CLIENT_ID", "legacy-client")
+	t.Setenv("M365_AUTHORITY", "https://login.microsoftonline.com/common")
+	t.Setenv("M365_SCOPE", "legacy-scope")
+	t.Setenv("M365_REDIRECT_URI", "https://login.microsoftonline.com/common/oauth2/nativeclient")
+
+	if ClientID() != "legacy-client" || DeviceClientID() != "legacy-client" {
+		t.Fatal("legacy client ID was not inherited")
+	}
+	if Scope() != "legacy-scope" || DeviceScope() != "legacy-scope" {
+		t.Fatal("legacy scope was not inherited")
+	}
+}

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -34,8 +34,8 @@ type deviceCodeResponse struct {
 
 func StartDeviceCode() (DeviceCode, error) {
 	form := url.Values{}
-	form.Set("client_id", ClientID())
-	form.Set("scope", Scope())
+	form.Set("client_id", DeviceClientID())
+	form.Set("scope", DeviceScope())
 	req, err := http.NewRequest(http.MethodPost, DeviceCodeEndpoint(), strings.NewReader(form.Encode()))
 	if err != nil {
 		return DeviceCode{}, err
@@ -77,10 +77,10 @@ func StartDeviceCode() (DeviceCode, error) {
 
 func PollDeviceCode(deviceCode string) (TokenSet, bool, error) {
 	form := url.Values{}
-	form.Set("client_id", ClientID())
+	form.Set("client_id", DeviceClientID())
 	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
 	form.Set("device_code", deviceCode)
-	req, err := http.NewRequest(http.MethodPost, TokenEndpoint(), strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(http.MethodPost, DeviceTokenEndpoint(), strings.NewReader(form.Encode()))
 	if err != nil {
 		return TokenSet{}, false, err
 	}


### PR DESCRIPTION
## 变更说明

将 Device Code OAuth 与浏览器 PKCE 的配置拆开，分别使用 `M365_DEVICE_*` 和 `M365_BROWSER_*`，并保留旧 `M365_CLIENT_ID` / `M365_AUTHORITY` / `M365_SCOPE` / `M365_REDIRECT_URI` 回退兼容。

这样修改某一种授权方式时不会意外改变另一种流程。

## 验证

- `go test -race ./internal/auth -run 'Test(BrowserAndDevice|LegacyOAuth)' -count=1`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

以上均通过。

`go test ./...` 仍包含上游 `main` 已存在的 `TestCompletionGuardRejectsUnsupportedSuccess` 失败；该失败已在未包含本 PR 的 `upstream/main` 独立复现。