### PR TITLE
fix(auth): harden PKCE callback lifecycle

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -27,14 +27,35 @@ type TokenSet struct {
 }
 
 type tokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	IDToken      string `json:"id_token"`
-	TokenType    string `json:"token_type"`
-	Scope        string `json:"scope"`
-	ExpiresIn    int    `json:"expires_in"`
-	Error        string `json:"error"`
-	ErrorDesc    string `json:"error_description"`
+	AccessToken   string `json:"access_token"`
+	RefreshToken  string `json:"refresh_token"`
+	IDToken       string `json:"id_token"`
+	TokenType     string `json:"token_type"`
+	Scope         string `json:"scope"`
+	ExpiresIn     int    `json:"expires_in"`
+	Error         string `json:"error"`
+	ErrorDesc     string `json:"error_description"`
+	CorrelationID string `json:"correlation_id"`
+	TraceID       string `json:"trace_id"`
+}
+
+type OAuthError struct {
+	Code          string
+	AADSTS        string
+	HTTPStatus    int
+	CorrelationID string
+	TraceID       string
+}
+
+func (e *OAuthError) Error() string {
+	parts := []string{e.Code}
+	if e.AADSTS != "" {
+		parts = append(parts, e.AADSTS)
+	}
+	if e.HTTPStatus != 0 {
+		parts = append(parts, fmt.Sprintf("HTTP %d", e.HTTPStatus))
+	}
+	return strings.Join(parts, ": ")
 }
 
 func (t TokenSet) Valid() bool {
@@ -150,7 +171,13 @@ func requestToken(form url.Values) (TokenSet, error) {
 		return TokenSet{}, fmt.Errorf("decode token response: %w", err)
 	}
 	if tr.Error != "" {
-		return TokenSet{}, fmt.Errorf("token endpoint HTTP %d: %s: %s", resp.StatusCode, tr.Error, tr.ErrorDesc)
+		return TokenSet{}, &OAuthError{
+			Code:          tr.Error,
+			AADSTS:        aadstsCode(tr.ErrorDesc),
+			HTTPStatus:    resp.StatusCode,
+			CorrelationID: firstNonEmpty(tr.CorrelationID, resp.Header.Get("client-request-id")),
+			TraceID:       firstNonEmpty(tr.TraceID, resp.Header.Get("x-ms-request-id")),
+		}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return TokenSet{}, fmt.Errorf("token endpoint HTTP %d", resp.StatusCode)
@@ -184,6 +211,22 @@ func requestToken(form url.Values) (TokenSet, error) {
 		}
 	}
 	return set, nil
+}
+
+func aadstsCode(description string) string {
+	const prefix = "AADSTS"
+	start := strings.Index(description, prefix)
+	if start < 0 {
+		return ""
+	}
+	end := start + len(prefix)
+	for end < len(description) && description[end] >= '0' && description[end] <= '9' {
+		end++
+	}
+	if end == start+len(prefix) {
+		return ""
+	}
+	return description[start:end]
 }
 
 func decodeJWTClaims(token string) (map[string]string, error) {

--- a/internal/web/errors.go
+++ b/internal/web/errors.go
@@ -1,10 +1,22 @@
 package web
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+
+	"m365-copilot2api/internal/auth"
 )
+
+func logOAuthError(stage string, err error) {
+	var oauthErr *auth.OAuthError
+	if errors.As(err, &oauthErr) {
+		log.Printf("oauth_error stage=%s error=%q aadsts=%q http_status=%d correlation_id=%q trace_id=%q", stage, oauthErr.Code, oauthErr.AADSTS, oauthErr.HTTPStatus, oauthErr.CorrelationID, oauthErr.TraceID)
+		return
+	}
+	log.Printf("oauth_error stage=%s error=%q", stage, "request_failed")
+}
 
 // upstreamError keeps transport details, including URLs and credentials, out
 // of client-visible responses while retaining a server-side diagnostic.

--- a/internal/web/pkce_test.go
+++ b/internal/web/pkce_test.go
@@ -2,11 +2,15 @@ package web
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"m365-copilot2api/internal/auth"
 )
 
 func TestStartPKCEUsesBrowserClientDefaults(t *testing.T) {
@@ -48,6 +52,116 @@ func TestStartPKCEUsesBrowserClientDefaults(t *testing.T) {
 	}
 	if got := u.Query().Get("redirect_uri"); got != response.RedirectURI {
 		t.Fatalf("authorization redirect URI = %q, response redirect URI = %q", got, response.RedirectURI)
+	}
+}
+
+func TestCallbackPKCERejectsMissingUnknownExpiredAndConsumedState(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  string
+		entry  pendingPKCE
+		add    bool
+		status int
+	}{
+		{name: "missing", status: http.StatusBadRequest},
+		{name: "unknown", state: "unknown", status: http.StatusBadRequest},
+		{name: "expired", state: "expired", entry: pendingPKCE{Created: time.Now().Add(-11 * time.Minute), Status: "pending"}, add: true, status: http.StatusBadRequest},
+		{name: "consumed", state: "consumed", entry: pendingPKCE{Created: time.Now(), Status: "authenticated"}, add: true, status: http.StatusConflict},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{pkce: map[string]pendingPKCE{}}
+			if tc.add {
+				s.pkce[tc.state] = tc.entry
+			}
+			path := "/api/auth/callback"
+			if tc.state != "" {
+				path += "?state=" + url.QueryEscape(tc.state) + "&code=code"
+			}
+			rr := httptest.NewRecorder()
+			s.callbackPKCE(rr, httptest.NewRequest(http.MethodGet, path, nil))
+			if rr.Code != tc.status {
+				t.Fatalf("status = %d, want %d; body = %s", rr.Code, tc.status, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestCallbackPKCEConsumesMicrosoftErrorOnce(t *testing.T) {
+	s := &Server{pkce: map[string]pendingPKCE{
+		"state": {Created: time.Now(), Status: "pending"},
+	}}
+	path := "/api/auth/callback?state=state&error=access_denied"
+	first := httptest.NewRecorder()
+	s.callbackPKCE(first, httptest.NewRequest(http.MethodGet, path, nil))
+	if first.Code != http.StatusBadRequest {
+		t.Fatalf("first status = %d, body = %s", first.Code, first.Body.String())
+	}
+	second := httptest.NewRecorder()
+	s.callbackPKCE(second, httptest.NewRequest(http.MethodGet, path, nil))
+	if second.Code != http.StatusConflict {
+		t.Fatalf("second status = %d, body = %s", second.Code, second.Body.String())
+	}
+}
+
+func TestCallbackPKCEAcceptsPastedURLAndReturnsSafeCompletionPage(t *testing.T) {
+	const code = "sensitive-authorization-code"
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if r.Form.Get("code") != code || r.Form.Get("code_verifier") != "verifier" {
+			t.Fatalf("unexpected exchange form: %v", r.Form)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"header.payload.signature","refresh_token":"sensitive-refresh-token","expires_in":3600}`)
+	}))
+	defer tokenServer.Close()
+	t.Setenv("M365_TOKEN_ENDPOINT", tokenServer.URL)
+	store, err := auth.OpenStore(t.TempDir() + "/accounts.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirectURI := "http://127.0.0.1:4141/api/auth/callback"
+	s := &Server{tokens: store, pkce: map[string]pendingPKCE{
+		"state": {Verifier: "verifier", Created: time.Now(), Status: "pending", RedirectURI: redirectURI},
+	}}
+	callbackURL := redirectURI + "?code=" + code + "&state=state"
+	rr := httptest.NewRecorder()
+	s.callbackPKCE(rr, httptest.NewRequest(http.MethodGet, "/api/auth/callback?url="+url.QueryEscape(callbackURL), nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, secret := range []string{code, "sensitive-refresh-token", callbackURL} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("completion page exposed sensitive value %q", secret)
+		}
+	}
+	if !strings.Contains(body, "window.close()") {
+		t.Fatal("completion page does not attempt to close the popup")
+	}
+}
+
+func TestCallbackPKCEFailureDoesNotExposeAuthorizationCode(t *testing.T) {
+	const code = "sensitive-failed-code"
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"invalid_grant","error_description":"AADSTS70000: invalid grant"}`)
+	}))
+	defer tokenServer.Close()
+	t.Setenv("M365_TOKEN_ENDPOINT", tokenServer.URL)
+	s := &Server{pkce: map[string]pendingPKCE{
+		"state": {Verifier: "verifier", Created: time.Now(), Status: "pending", RedirectURI: auth.DefaultRedirectURI},
+	}}
+	rr := httptest.NewRecorder()
+	s.callbackPKCE(rr, httptest.NewRequest(http.MethodGet, "/api/auth/callback?state=state&code="+code, nil))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), code) || strings.Contains(s.pkce["state"].Error, code) {
+		t.Fatal("failed exchange exposed authorization code")
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -25,11 +25,12 @@ import (
 )
 
 type pendingPKCE struct {
-	Verifier string
-	Created  time.Time
-	Status   string
-	Account  any
-	Error    string
+	Verifier    string
+	Created     time.Time
+	Status      string
+	Account     any
+	Error       string
+	RedirectURI string
 }
 
 // rateLimitCooldown is how long a rate-limited account stays out of rotation.
@@ -561,7 +562,7 @@ func (s *Server) startPKCE(w http.ResponseWriter, _ *http.Request) {
 	state := hex.EncodeToString(b)
 	redirectURI := auth.RedirectURI()
 	s.mu.Lock()
-	s.pkce[state] = pendingPKCE{Verifier: v, Created: time.Now(), Status: "pending"}
+	s.pkce[state] = pendingPKCE{Verifier: v, Created: time.Now(), Status: "pending", RedirectURI: redirectURI}
 	s.mu.Unlock()
 	jsonOut(w, map[string]string{
 		"status": "pkce_ready",
@@ -609,30 +610,58 @@ func (s *Server) pkceStatus(w http.ResponseWriter, r *http.Request) {
 func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 	state := r.URL.Query().Get("state")
 	code := r.URL.Query().Get("code")
+	oauthError := r.URL.Query().Get("error")
 	// also accept pasted full callback URL
-	if code == "" {
+	if code == "" && oauthError == "" {
 		if u := r.URL.Query().Get("url"); u != "" {
 			if parsed, err := http.NewRequest(http.MethodGet, u, nil); err == nil {
 				code = parsed.URL.Query().Get("code")
+				oauthError = parsed.URL.Query().Get("error")
 				if state == "" {
 					state = parsed.URL.Query().Get("state")
 				}
 			}
 		}
 	}
-	if state == "" || code == "" {
-		http.Error(w, "missing state or code", http.StatusBadRequest)
+	if state == "" || (code == "" && oauthError == "") {
+		http.Error(w, "missing state or authorization result", http.StatusBadRequest)
 		return
 	}
 	s.mu.Lock()
 	p, ok := s.pkce[state]
-	s.mu.Unlock()
 	if !ok || time.Since(p.Created) > 10*time.Minute {
+		if ok {
+			delete(s.pkce, state)
+		}
+		s.mu.Unlock()
 		http.Error(w, "invalid or expired state", http.StatusBadRequest)
 		return
 	}
-	tok, err := auth.ExchangeCode(code, p.Verifier, auth.RedirectURI())
+	if p.Status != "pending" {
+		s.mu.Unlock()
+		http.Error(w, "authorization result already consumed", http.StatusConflict)
+		return
+	}
+	p.Status = "processing"
+	s.pkce[state] = p
+	s.mu.Unlock()
+	if oauthError != "" {
+		log.Printf("oauth_error stage=callback error=%q", oauthError)
+		s.mu.Lock()
+		p.Status = "error"
+		p.Error = oauthError
+		s.pkce[state] = p
+		s.mu.Unlock()
+		http.Error(w, "Microsoft authorization failed: "+oauthError, http.StatusBadRequest)
+		return
+	}
+	redirectURI := p.RedirectURI
+	if redirectURI == "" {
+		redirectURI = auth.RedirectURI()
+	}
+	tok, err := auth.ExchangeCode(code, p.Verifier, redirectURI)
 	if err != nil {
+		logOAuthError("code_exchange", err)
 		s.mu.Lock()
 		p.Status = "error"
 		p.Error = err.Error()
@@ -658,7 +687,7 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 	// Browser loopback callbacks should finish in a friendly page instead of
 	// displaying a raw JSON response. Keep JSON for the manual/API flow.
-	if strings.HasPrefix(auth.RedirectURI(), "http://127.0.0.1:") || strings.HasPrefix(auth.RedirectURI(), "http://localhost:") {
+	if strings.HasPrefix(redirectURI, "http://127.0.0.1:") || strings.HasPrefix(redirectURI, "http://localhost:") {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		fmt.Fprint(w, `<!doctype html><meta charset="utf-8"><title>M365 Copilot2API 授权完成</title><style>body{font:16px system-ui;text-align:center;padding:15vh 20px;color:#242424}main{max-width:520px;margin:auto}h1{font-size:26px}</style><main><h1>授权完成</h1><p>账号已经自动加入账号池，可以关闭此页面。</p><script>if(window.opener){window.opener.postMessage({type:"m365-auth-complete"},window.location.origin);setTimeout(()=>window.close(),300)}</script></main>`)
 		return


### PR DESCRIPTION
## 变更说明

加固浏览器 PKCE 回调生命周期：

- 授权开始时固定并保存实际 redirect URI
- state 一次性消费，拒绝未知、过期和重复回调
- 正确处理 OAuth error 回调
- 成功/失败页面不回显 authorization code 或 token
- 兼容粘贴完整 callback URL 的现有流程

## 验证

- `go test -race ./internal/web -run 'TestCallbackPKCE' -count=1`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

以上均通过。

`go test ./...` 仍包含上游 `main` 已存在的 `TestCompletionGuardRejectsUnsupportedSuccess` 失败；该失败已在未包含本 PR 的 `upstream/main` 独立复现。