### PR TITLE
test(ci): restore Linux temporary directory environment

### DIFF
--- a/internal/web/auto_cleanup_test.go
+++ b/internal/web/auto_cleanup_test.go
@@ -14,7 +14,7 @@ func newTestServerForAutoCleanup(t *testing.T) *Server {
 	t.Setenv("M365_SESSION_CACHE", filepath.Join(dir, "sessions.json"))
 	t.Setenv("M365_CONVERSATION_CACHE", filepath.Join(dir, "conversations.json"))
 	t.Setenv("M365_USER_SESSION_CACHE", filepath.Join(dir, "users.json"))
-	os.Setenv("TMPDIR", dir)
+	t.Setenv("TMPDIR", dir)
 	return &Server{
 		sessions:            openSessionStore(),
 		userSessions:        openUserSessionStore(30 * time.Minute),


### PR DESCRIPTION
## Summary

Restore TMPDIR after each auto-cleanup test by using t.Setenv instead of os.Setenv.

The current main branch leaves TMPDIR pointing at the first test's deleted t.TempDir on Linux. Every later t.TempDir then fails with "no such file or directory", which makes CI fail for main and all pull requests.

## Verification

- go test ./... on Windows
- docker run --rm -v "${PWD}:/src" -w /src golang:1.23 go test ./... on Linux
- git diff --check