### PR TITLE
fix(web): apply completion guard only when tools are declared

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2014,7 +2014,7 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 		writeOpenAIError(w, http.StatusServiceUnavailable, "upstream_content_blocked", "M365 content policy blocked this request; try again or switch account")
 		return
 	}
-	if !completionEvidenceAllows(res.Text, ledger) {
+	if len(toolMaps) > 0 && !completionEvidenceAllows(res.Text, ledger) {
 		res.Text = "I cannot confirm completion because no matching tool results were returned. No external action has been verified."
 	}
 	res.Text = sanitizePublicAssistantTextForModel(res.Text, body.Model)


### PR DESCRIPTION
## Problem

Pure-chat requests (no tools declared) are being rejected by the completion guard when the answer contains success verbs (`completed`/`written`/`created` etc). A valid 11KB+ answer gets replaced with a 113-byte refusal template:

`I cannot confirm completion because no matching tool results were returned.`

This regressed in aae1f71, which reverted the 8c200e5 fix (`skip evidence check when no tools involved`). The revert's intent (block hallucinated completion claims) is fine, but the implementation can't distinguish:

- agent request with tools declared, model claims success without calling them → should be blocked
- pure chat (tools=0), answer naturally contains `completed`/`written` → must pass

`completionEvidenceAllows` only receives `answer` + `ledger`, not whether the request declared tools.

## Fix

Scope the guard to requests that actually declared tools (`len(toolMaps) > 0`):

```go
if len(toolMaps) > 0 && !completionEvidenceAllows(res.Text, ledger) {
    res.Text = "I cannot confirm completion because no matching tool results were returned. No external action has been verified."
}
```

- No tools declared → answer passes through untouched (pure chat, doc generation, math proofs)
- Tools declared → existing `completionEvidenceAllows` check still applies (anti-hallucination for agent workflows preserved)

## Verification

- `go test ./internal/web/` passes (including `TestCompletionGuard*` and `TestBuildAnswerRequest*` from aae1f71)
- Live test: order-stat tree design request (11.3KB answer) previously replaced with 113B template → now returns full answer