### PR TITLE
fix: 22 verified bugs across auth/web/mcp modules

### DIFF
--- a/internal/auth/cache.go
+++ b/internal/auth/cache.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,7 +180,7 @@ func (s *Store) Upsert(tok TokenSet) (AccountToken, error) {
 		id = tok.Email
 	}
 	if id == "" {
-		id = "account-" + time.Now().Format("150405")
+		id = fmt.Sprintf("account-%s-%04x", time.Now().Format("150405"), rand.Intn(0x10000))
 	}
 	acc := AccountToken{
 		ID:           id,
@@ -280,26 +282,37 @@ func (s *Store) Next() (AccountToken, bool) {
 }
 
 func (s *Store) EnsureValid(id string) (AccountToken, error) {
-	acc, ok := s.Get(id)
-	if !ok {
+	s.mu.Lock()
+	var acc AccountToken
+	found := false
+	for _, a := range s.data.Accounts {
+		if a.ID == id || a.OID == id || a.Email == id {
+			acc = a
+			found = true
+			break
+		}
+	}
+	if !found {
+		s.mu.Unlock()
 		return AccountToken{}, os.ErrNotExist
 	}
 	if time.Now().Before(acc.ExpiresAt.Add(-30 * time.Second)) {
+		s.mu.Unlock()
 		return acc, nil
 	}
 	if acc.RefreshToken == "" {
-		acc.Status = "expired"
-		s.mu.Lock()
 		for i, a := range s.data.Accounts {
 			if a.ID == acc.ID {
-				s.data.Accounts[i] = acc
+				s.data.Accounts[i].Status = "expired"
 				_ = s.saveLocked()
 				break
 			}
 		}
 		s.mu.Unlock()
+		acc.Status = "expired"
 		return acc, fmtExpired()
 	}
+	s.mu.Unlock()
 	return s.refreshInflight(acc)
 }
 
@@ -320,13 +333,16 @@ func (s *Store) refreshInflight(acc AccountToken) (AccountToken, error) {
 	s.inflight[acc.ID] = f
 	s.mu.Unlock()
 
-	tok, err := Refresh(acc.RefreshToken)
+	endpoint := TokenEndpoint()
+	if acc.ClientID == DeviceClientID() {
+		endpoint = DeviceTokenEndpoint()
+	}
+	tok, err := Refresh(acc.RefreshToken, acc.ClientID, endpoint)
 	if err != nil {
-		acc.Status = "expired"
 		s.mu.Lock()
 		for i, a := range s.data.Accounts {
 			if a.ID == acc.ID {
-				s.data.Accounts[i] = acc
+				s.data.Accounts[i].Status = "expired"
 				_ = s.saveLocked()
 				break
 			}

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -106,9 +106,7 @@ func PollDeviceCode(deviceCode string) (TokenSet, bool, error) {
 	case "expired_token", "authorization_declined", "bad_verification_code":
 		return TokenSet{}, false, fmt.Errorf("%s: %s", tr.Error, tr.ErrorDesc)
 	default:
-		if tr.AccessToken == "" {
-			return TokenSet{}, false, fmt.Errorf("%s: %s", tr.Error, tr.ErrorDesc)
-		}
+		return TokenSet{}, false, fmt.Errorf("%s: %s", tr.Error, tr.ErrorDesc)
 	}
 	if tr.AccessToken == "" {
 		return TokenSet{}, false, fmt.Errorf("token endpoint returned no access token")

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -73,13 +73,19 @@ func ExchangeCode(code, verifier, redirect string) (TokenSet, error) {
 	return requestToken(form)
 }
 
-func Refresh(refreshToken string) (TokenSet, error) {
+func Refresh(refreshToken, clientID, tokenEndpoint string) (TokenSet, error) {
 	form := url.Values{}
-	form.Set("client_id", ClientID())
+	if clientID == "" {
+		clientID = ClientID()
+	}
+	if tokenEndpoint == "" {
+		tokenEndpoint = TokenEndpoint()
+	}
+	form.Set("client_id", clientID)
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 	form.Set("scope", Scope())
-	return requestToken(form)
+	return requestTokenTenant(form, tokenEndpoint)
 }
 
 // RefreshWithScope redeems the same account refresh token for a separately

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -15,13 +15,15 @@ import (
 // Client is an MCP client that connects to an MCP server via HTTP SSE.
 // It implements the MCP client protocol: discover tools, invoke tools.
 type Client struct {
-	serverURL string
+	serverURL  string
 	httpClient *http.Client
 	sessionID  string
 	mu         sync.Mutex
 	connected  bool
-	msgCh      chan json.RawMessage
+	pending    map[int64]chan json.RawMessage
 	done       chan struct{}
+	sseCancel  context.CancelFunc
+	sseBody    io.Closer
 }
 
 // NewClient creates a new MCP client that connects to the given server URL.
@@ -29,7 +31,7 @@ func NewClient(serverURL string) *Client {
 	return &Client{
 		serverURL:  serverURL,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
-		msgCh:      make(chan json.RawMessage, 64),
+		pending:    map[int64]chan json.RawMessage{},
 		done:       make(chan struct{}),
 	}
 }
@@ -76,7 +78,6 @@ func (c *Client) Connect(ctx context.Context) error {
 
 	// Parse the SSE response to get the session ID and endpoint
 	scanner := bufio.NewScanner(resp.Body)
-	messageURL := ""
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "data: ") {
@@ -87,11 +88,10 @@ func (c *Client) Connect(ctx context.Context) error {
 			// Next line should contain the data with the message URL
 			continue
 		}
-		if strings.HasPrefix(line, "data: /message?") {
-			messageURL = strings.TrimPrefix(line, "data: ")
-			// Parse session ID from the URL
-			if idx := strings.Index(messageURL, "sessionId="); idx >= 0 {
-				c.sessionID = messageURL[idx+10:]
+		if strings.Contains(line, "sessionId=") {
+			data := strings.TrimPrefix(line, "data: ")
+			if idx := strings.Index(data, "sessionId="); idx >= 0 {
+				c.sessionID = data[idx+10:]
 			}
 			break
 		}
@@ -103,11 +103,13 @@ func (c *Client) Connect(ctx context.Context) error {
 	}
 
 	// Start background goroutine to read SSE events
-	c.setConnected(true)
+	sseCtx, cancel := context.WithCancel(ctx)
+	c.sseCancel = cancel
+	c.sseBody = resp.Body
+	c.connected = true
 	go c.readSSE(resp.Body)
 
-	// Initialize the session
-	err = c.sendRequest(ctx, "initialize", map[string]any{
+	_, err = c.sendRequest(sseCtx, "initialize", map[string]any{
 		"protocolVersion": "2024-11-05",
 		"capabilities":    map[string]any{},
 		"clientInfo":      map[string]any{"name": "m365-copilot2api-mcp-client", "version": "0.1.0"},
@@ -132,11 +134,18 @@ func (c *Client) readSSE(body io.ReadCloser) {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "data: ") {
 			data := strings.TrimPrefix(line, "data: ")
-			var msg json.RawMessage
-			if err := json.Unmarshal([]byte(data), &msg); err == nil {
-				select {
-				case c.msgCh <- msg:
-				default:
+			var meta struct {
+				ID *int64 `json:"id"`
+			}
+			if json.Unmarshal([]byte(data), &meta) == nil && meta.ID != nil {
+				c.mu.Lock()
+				ch := c.pending[*meta.ID]
+				c.mu.Unlock()
+				if ch != nil {
+					select {
+					case ch <- json.RawMessage(data):
+					default:
+					}
 				}
 			}
 		}
@@ -148,15 +157,14 @@ func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
 	var result struct {
 		Tools []Tool `json:"tools"`
 	}
-	err := c.sendRequest(ctx, "tools/list", nil)
+	id, err := c.sendRequest(ctx, "tools/list", nil)
 	if err != nil {
 		return nil, err
 	}
-	// Wait for the response
+	ch := c.getPending(id)
 	select {
-	case msg := <-c.msgCh:
+	case msg := <-ch:
 		var resp struct {
-			ID     int64           `json:"id"`
 			Result json.RawMessage `json:"result"`
 		}
 		if err := json.Unmarshal(msg, &resp); err != nil {
@@ -176,18 +184,17 @@ func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
 // CallTool invokes a tool on the MCP server.
 func (c *Client) CallTool(ctx context.Context, name string, arguments map[string]any) (CallResult, error) {
 	var result CallResult
-	err := c.sendRequest(ctx, "tools/call", map[string]any{
+	id, err := c.sendRequest(ctx, "tools/call", map[string]any{
 		"name":      name,
 		"arguments": arguments,
 	})
 	if err != nil {
 		return result, err
 	}
-	// Wait for the response
+	ch := c.getPending(id)
 	select {
-	case msg := <-c.msgCh:
+	case msg := <-ch:
 		var resp struct {
-			ID     int64           `json:"id"`
 			Result json.RawMessage `json:"result"`
 		}
 		if err := json.Unmarshal(msg, &resp); err != nil {
@@ -204,7 +211,13 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments map[string
 	return result, nil
 }
 
-func (c *Client) sendRequest(ctx context.Context, method string, params any) error {
+func (c *Client) getPending(id int64) chan json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pending[id]
+}
+
+func (c *Client) sendRequest(ctx context.Context, method string, params any) (int64, error) {
 	id := time.Now().UnixNano()
 	req := map[string]any{
 		"jsonrpc": "2.0",
@@ -216,20 +229,33 @@ func (c *Client) sendRequest(ctx context.Context, method string, params any) err
 	}
 	body, _ := json.Marshal(req)
 
+	ch := make(chan json.RawMessage, 1)
+	c.mu.Lock()
+	c.pending[id] = ch
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+	}()
+
 	messageURL := fmt.Sprintf("%s/message?sessionId=%s", strings.TrimRight(strings.Split(c.serverURL, "/sse")[0], "/"), c.sessionID)
 	
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, messageURL, strings.NewReader(string(body)))
 	if err != nil {
-		return err
+		return 0, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer resp.Body.Close()
-	return nil
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, fmt.Errorf("http status: %s", resp.Status)
+	}
+	return id, nil
 }
 
 func (c *Client) sendNotification(method string, params any) error {
@@ -262,6 +288,16 @@ func (c *Client) sendNotification(method string, params any) error {
 func (c *Client) Close() error {
 	c.mu.Lock()
 	c.connected = false
+	cancel := c.sseCancel
+	body := c.sseBody
+	c.sseCancel = nil
+	c.sseBody = nil
 	c.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if body != nil {
+		body.Close()
+	}
 	return nil
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -109,7 +109,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	c.connected = true
 	go c.readSSE(resp.Body)
 
-	_, err = c.sendRequest(sseCtx, "initialize", map[string]any{
+	_, initCh, err := c.sendRequest(sseCtx, "initialize", map[string]any{
 		"protocolVersion": "2024-11-05",
 		"capabilities":    map[string]any{},
 		"clientInfo":      map[string]any{"name": "m365-copilot2api-mcp-client", "version": "0.1.0"},
@@ -117,6 +117,12 @@ func (c *Client) Connect(ctx context.Context) error {
 	if err != nil {
 		c.Close()
 		return fmt.Errorf("initialize: %w", err)
+	}
+	select {
+	case <-initCh:
+	case <-time.After(10 * time.Second):
+		c.Close()
+		return fmt.Errorf("timeout waiting for initialize response")
 	}
 
 	// Send initialized notification
@@ -157,11 +163,15 @@ func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
 	var result struct {
 		Tools []Tool `json:"tools"`
 	}
-	id, err := c.sendRequest(ctx, "tools/list", nil)
+	id, ch, err := c.sendRequest(ctx, "tools/list", nil)
 	if err != nil {
 		return nil, err
 	}
-	ch := c.getPending(id)
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+	}()
 	select {
 	case msg := <-ch:
 		var resp struct {
@@ -184,14 +194,18 @@ func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
 // CallTool invokes a tool on the MCP server.
 func (c *Client) CallTool(ctx context.Context, name string, arguments map[string]any) (CallResult, error) {
 	var result CallResult
-	id, err := c.sendRequest(ctx, "tools/call", map[string]any{
+	id, ch, err := c.sendRequest(ctx, "tools/call", map[string]any{
 		"name":      name,
 		"arguments": arguments,
 	})
 	if err != nil {
 		return result, err
 	}
-	ch := c.getPending(id)
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+	}()
 	select {
 	case msg := <-ch:
 		var resp struct {
@@ -211,13 +225,7 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments map[string
 	return result, nil
 }
 
-func (c *Client) getPending(id int64) chan json.RawMessage {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.pending[id]
-}
-
-func (c *Client) sendRequest(ctx context.Context, method string, params any) (int64, error) {
+func (c *Client) sendRequest(ctx context.Context, method string, params any) (int64, chan json.RawMessage, error) {
 	id := time.Now().UnixNano()
 	req := map[string]any{
 		"jsonrpc": "2.0",
@@ -233,29 +241,33 @@ func (c *Client) sendRequest(ctx context.Context, method string, params any) (in
 	c.mu.Lock()
 	c.pending[id] = ch
 	c.mu.Unlock()
-	defer func() {
-		c.mu.Lock()
-		delete(c.pending, id)
-		c.mu.Unlock()
-	}()
 
 	messageURL := fmt.Sprintf("%s/message?sessionId=%s", strings.TrimRight(strings.Split(c.serverURL, "/sse")[0], "/"), c.sessionID)
 	
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, messageURL, strings.NewReader(string(body)))
 	if err != nil {
-		return 0, err
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return 0, nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return 0, err
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return 0, nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return 0, fmt.Errorf("http status: %s", resp.Status)
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return 0, nil, fmt.Errorf("http status: %s", resp.Status)
 	}
-	return id, nil
+	return id, ch, nil
 }
 
 func (c *Client) sendNotification(method string, params any) error {

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -81,15 +81,17 @@ func (c *StdioClient) call(ctx context.Context, method string, id int64, params 
 	c.mu.Lock()
 	ch := make(chan json.RawMessage, 1)
 	c.pending[id] = ch
+	if _, err := c.stdin.Write(b); err != nil {
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, err
+	}
 	c.mu.Unlock()
 	defer func() {
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()
 	}()
-	if _, err := c.stdin.Write(b); err != nil {
-		return nil, err
-	}
 	select {
 	case raw := <-ch:
 		return raw, nil

--- a/internal/outbound/pool.go
+++ b/internal/outbound/pool.go
@@ -157,7 +157,10 @@ func (t *poolRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if r.Body != nil && r.GetBody == nil {
 		return resp, err
 	}
-	for i := 0; i < len(t.pool.entries)+1; i++ {
+	t.pool.mu.Lock()
+	n := len(t.pool.entries) + 1
+	t.pool.mu.Unlock()
+	for i := 0; i < n; i++ {
 		next := t.pool.pick()
 		if next == nil || next == t.entry {
 			break

--- a/internal/web/codex_catalog.go
+++ b/internal/web/codex_catalog.go
@@ -252,7 +252,7 @@ func reasoningTone(model, effort string) (string, error) {
 	case "gpt-5.5":
 		return "Gpt_5_5_Reasoning", nil
 	case "gpt-5.6":
-		return "Gpt_5_5_Reasoning", nil
+		return "Gpt_5_6_Reasoning", nil
 	default:
 		return "Gpt_5_5_Reasoning", nil
 	}

--- a/internal/web/conversation_manager.go
+++ b/internal/web/conversation_manager.go
@@ -112,13 +112,18 @@ func (cm *conversationManager) Record(conversationID, accountID, title string) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	now := time.Now().UTC()
-	cm.data[conversationID] = managedConversation{
+	existing, hasExisting := cm.data[conversationID]
+	rec := managedConversation{
 		ID:         conversationID,
 		AccountID:  accountID,
 		CreatedAt:  now,
 		LastUsedAt: now,
 		Title:      title,
 	}
+	if hasExisting {
+		rec.CreatedAt = existing.CreatedAt
+	}
+	cm.data[conversationID] = rec
 	cm.persist.markDirty()
 	log.Printf("[conversation-manager] recorded conversation %s", conversationID)
 }

--- a/internal/web/conversations.go
+++ b/internal/web/conversations.go
@@ -29,10 +29,7 @@ func (s *Server) deleteConversation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.conversationManager.Delete(body.ID)
-	if !s.sessions.delete(body.ID) {
-		http.Error(w, "conversation not found", http.StatusNotFound)
-		return
-	}
+	s.sessions.delete(body.ID)
 	jsonOut(w, map[string]string{"status": "deleted"})
 }
 

--- a/internal/web/debug.go
+++ b/internal/web/debug.go
@@ -44,11 +44,13 @@ func openDebugStore() *debugStore {
 	return &debugStore{path: p}
 }
 var sensitiveKeys = map[string]bool{
-	"api_key": true, "apikey": true, "apiKey": true, "authorization": true,
-	"access_token": true, "accessToken": true, "refresh_token": true, "refreshToken": true,
-	"client_secret": true, "clientSecret": true, "password": true, "current_password": true,
+	"api_key": true, "apikey": true, "accesstoken": true, "authorization": true,
+	"access_token": true, "refreshtoken": true, "refresh_token": true,
+	"clientsecret": true, "client_secret": true, "password": true, "current_password": true,
 	"new_password": true, "token": true, "bearer": true, "session_key": true,
 	"secret": true, "next_token": true, "pkce_verifier": true, "code_verifier": true,
+	"sessionkey": true, "nexttoken": true, "pkceverifier": true, "codeverifier": true,
+	"currentpassword": true, "newpassword": true,
 }
 
 func redactBody(b []byte) any {

--- a/internal/web/deployments.go
+++ b/internal/web/deployments.go
@@ -203,14 +203,16 @@ func (s *Server) deploymentCheck(w http.ResponseWriter, r *http.Request) {
 	id := r.URL.Query().Get("id")
 	st := openDeployments()
 	st.mu.Lock()
-	var d *deployment
+	var d deployment
+	found := false
 	for i := range st.Items {
 		if st.Items[i].ID == id {
-			d = &st.Items[i]
+			d = st.Items[i]
+			found = true
 			break
 		}
 	}
-	if d == nil {
+	if !found {
 		st.mu.Unlock()
 		writeOpenAIError(w, 404, "not_found", "deployment not found")
 		return
@@ -225,23 +227,27 @@ func (s *Server) deploymentCheck(w http.ResponseWriter, r *http.Request) {
 	resp, e := deploymentHTTPClient.Do(req)
 	lat := time.Since(start).Milliseconds()
 	st.mu.Lock()
-	if e != nil {
-		d.Status = "unhealthy"
-		d.LastError = e.Error()
-	} else if resp.StatusCode != http.StatusOK {
-		d.Status = "unhealthy"
-		d.LastError = fmt.Sprintf("health returned %s", resp.Status)
-		resp.Body.Close()
-	} else {
-		d.Status = "healthy"
-		d.LastError = ""
-		d.LatencyMs = lat
-		d.LastCheckedAt = time.Now()
-		resp.Body.Close()
-		// Health alone does not prove HTTP proxy forwarding. Keep deployment records
-		// separate until an authenticated relay endpoint is implemented and verified.
+	var out deployment
+	for i := range st.Items {
+		if st.Items[i].ID == id {
+			if e != nil {
+				st.Items[i].Status = "unhealthy"
+				st.Items[i].LastError = e.Error()
+			} else if resp.StatusCode != http.StatusOK {
+				st.Items[i].Status = "unhealthy"
+				st.Items[i].LastError = fmt.Sprintf("health returned %s", resp.Status)
+				resp.Body.Close()
+			} else {
+				st.Items[i].Status = "healthy"
+				st.Items[i].LastError = ""
+				st.Items[i].LatencyMs = lat
+				st.Items[i].LastCheckedAt = time.Now()
+				resp.Body.Close()
+			}
+			out = st.Items[i]
+			break
+		}
 	}
-	out := *d
 	st.mu.Unlock()
 	_ = st.save()
 	jsonOut(w, map[string]any{"ok": e == nil, "deployment": out})

--- a/internal/web/images.go
+++ b/internal/web/images.go
@@ -53,6 +53,7 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var b imageGenerationRequest
+	r.Body = http.MaxBytesReader(w, r.Body, maxImageEditRequestBytes)
 	if json.NewDecoder(r.Body).Decode(&b) != nil || strings.TrimSpace(b.Prompt) == "" {
 		http.Error(w, `{"error":{"message":"prompt is required","type":"invalid_request_error"}}`, 400)
 		return
@@ -528,9 +529,17 @@ func downloadImageAsDataURI(url string) (string, error) {
 func downloadImageAsDataURIWithToken(url, token string) (string, error) {
 	b64, ct, err := downloadImageAsBase64WithToken(url, token)
 	if err != nil {
-		log.Printf("[image-download] failed url=%s token_len=%d err=%v", url[:80], len(token), err)
+		urlPreview := url
+		if len(urlPreview) > 80 {
+			urlPreview = urlPreview[:80]
+		}
+		log.Printf("[image-download] failed url=%s token_len=%d err=%v", urlPreview, len(token), err)
 		return url, nil
 	}
-	log.Printf("[image-download] ok url=%s ct=%s size=%d", url[:80], ct, len(b64))
+	urlPreview := url
+	if len(urlPreview) > 80 {
+		urlPreview = urlPreview[:80]
+	}
+	log.Printf("[image-download] ok url=%s ct=%s size=%d", urlPreview, ct, len(b64))
 	return "data:" + ct + ";base64," + b64, nil
 }

--- a/internal/web/keys.go
+++ b/internal/web/keys.go
@@ -148,10 +148,14 @@ func (s *apiKeyStore) delete(id string) (bool, error) {
 func (s *apiKeyStore) update(id, name string, revoked *bool) (bool, error) {
 	s.mu.Lock()
 	found := false
+	var oldName string
+	var oldRevoked bool
 	for i := range s.Keys {
 		if s.Keys[i].ID != id {
 			continue
 		}
+		oldName = s.Keys[i].Name
+		oldRevoked = s.Keys[i].Revoked
 		if name != "" {
 			s.Keys[i].Name = name
 		}
@@ -166,6 +170,15 @@ func (s *apiKeyStore) update(id, name string, revoked *bool) (bool, error) {
 		return false, nil
 	}
 	if err := s.persist.flushNowBlocking(); err != nil {
+		s.mu.Lock()
+		for i := range s.Keys {
+			if s.Keys[i].ID == id {
+				s.Keys[i].Name = oldName
+				s.Keys[i].Revoked = oldRevoked
+				break
+			}
+		}
+		s.mu.Unlock()
 		return false, err
 	}
 	return true, nil

--- a/internal/web/m365cloud.go
+++ b/internal/web/m365cloud.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -55,10 +56,12 @@ func (c *M365CloudClient) getAccessToken() (string, error) {
 		return c.accessToken, nil
 	}
 
-	payload := fmt.Sprintf(
-		"client_id=%s&refresh_token=%s&grant_type=refresh_token&scope=https://m365.cloud.microsoft/v2/.default",
-		c.clientID, c.refreshToken,
-	)
+	v := url.Values{}
+	v.Set("client_id", c.clientID)
+	v.Set("refresh_token", c.refreshToken)
+	v.Set("grant_type", "refresh_token")
+	v.Set("scope", "https://m365.cloud.microsoft/v2/.default")
+	payload := v.Encode()
 
 	resp, err := c.httpClient.Post(
 		fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", c.tenantID),
@@ -244,8 +247,11 @@ func (c *M365CloudClient) CleanupOldConversations(maxAge time.Duration, keepN in
 		anyDeleted := false
 		for _, chat := range chats {
 			convID, _ := chat["conversationId"].(string)
-			createTime, _ := chat["createTimeUtc"].(float64)
+			createTime, ok := chat["createTimeUtc"].(float64)
 			if convID == "" {
+				continue
+			}
+			if !ok {
 				continue
 			}
 

--- a/internal/web/protocol_handlers.go
+++ b/internal/web/protocol_handlers.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"time"
 
@@ -108,8 +109,15 @@ func (s *Server) streamResponsesAdapter(w http.ResponseWriter, r *http.Request, 
 		}
 		if rawCalls, ok := delta["tool_calls"].([]any); ok {
 			for _, raw := range rawCalls {
-				tc, _ := raw.(map[string]any)
-				idx := int(tc["index"].(float64))
+				tc, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				idxFloat, ok := tc["index"].(float64)
+				if !ok {
+					continue
+				}
+				idx := int(idxFloat)
 				st := calls[idx]
 				typ := "function"
 				if v, ok := tc["type"].(string); ok && v == "custom" {
@@ -173,7 +181,12 @@ func (s *Server) streamResponsesAdapter(w http.ResponseWriter, r *http.Request, 
 	}
 	output := []any{}
 	if len(calls) > 0 {
-		for i := 0; i < len(calls); i++ {
+		keys := make([]int, 0, len(calls))
+		for k := range calls {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+		for _, i := range keys {
 			st := calls[i]
 			if st == nil {
 				continue

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -487,9 +487,6 @@ func (s *Server) validAPIKey(r *http.Request) bool {
 	if raw != "" && s.apiKeys.valid(raw) {
 		return true
 	}
-	if strings.HasPrefix(raw, "eyJ") {
-		return true
-	}
 	return false
 }
 
@@ -722,19 +719,15 @@ func (s *Server) bindProxy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	oldAcc, _ := s.tokens.Get(body.ID)
 	if err := s.tokens.SetBoundProxy(body.ID, body.ProxyURL); err != nil {
 		writeOpenAIError(w, http.StatusNotFound, "not_found", err.Error())
 		return
 	}
-	acc, _ := s.tokens.Get(body.ID)
-	if acc.BoundProxy == "" {
-		s.proxyClients.Range(func(key, _ any) bool {
-			if keyStr, ok := key.(string); ok && keyStr != "" {
-				s.proxyClients.Delete(keyStr)
-			}
-			return true
-		})
+	if body.ProxyURL == "" && oldAcc.BoundProxy != "" {
+		s.proxyClients.Delete(oldAcc.BoundProxy)
 	}
+	acc, _ := s.tokens.Get(body.ID)
 	jsonOut(w, map[string]any{"ok": true, "id": body.ID, "boundProxy": acc.BoundProxy})
 }
 
@@ -1714,7 +1707,13 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 				msg = "upstream is rate limiting; try again shortly"
 			}
 			msg = sanitizePublicInternalText(msg)
-			_ = sseRaw(r.Context(), w, flusher, "data: "+mustJSON(map[string]any{"error": map[string]any{"message": msg, "code": "rate_limit"}})+"\n\n")
+			errCode := "upstream_error"
+			if IsRateLimited(err) {
+				errCode = "rate_limit"
+			} else if IsAuthFailure(err) {
+				errCode = "auth_failure"
+			}
+			_ = sseRaw(r.Context(), w, flusher, "data: "+mustJSON(map[string]any{"error": map[string]any{"message": msg, "code": errCode}})+"\n\n")
 			_ = sseRaw(r.Context(), w, flusher, "data: [DONE]\n\n")
 			return
 		}
@@ -1768,6 +1767,16 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 			s.bindConversation(acc, &body, r, res, answerPrompt, startedAt)
 			s.storeConvCache(acc.ID, convCacheModel, res, tone, body.Messages, convReused)
 			return
+		}
+		if responseFormat != nil && (responseFormat.Type == "json_object" || responseFormat.Type == "json_schema") {
+			normalized := normalizeJSONText(text.String())
+			if normalized != text.String() {
+				text.Reset()
+				text.WriteString(normalized)
+				pending.Reset()
+				pending.WriteString(normalized)
+			}
+			res.Text = normalized
 		}
 		if err := emitText(pending.String()); err != nil {
 			log.Printf("[req-trace] id=%s stage=stream_write err=%v", requestID, err)
@@ -1954,6 +1963,9 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 			}
 			res.Text = sanitizePublicAssistantTextForModel(res.Text, body.Model)
 			res.Reasoning = sanitizePublicReasoningText(res.Reasoning)
+			if responseFormat != nil && (responseFormat.Type == "json_object" || responseFormat.Type == "json_schema") {
+				res.Text = normalizeJSONText(res.Text)
+			}
 			s.accountPool.MarkSuccess(acc.ID)
 		} else {
 			log.Printf("[req-trace] id=%s stage=stream_error err=%v", requestID, err)
@@ -1966,7 +1978,13 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 				msg = "upstream is rate limiting; try again shortly"
 			}
 			msg = sanitizePublicInternalText(msg)
-			_ = sseRaw(r.Context(), w, flusher, "data: "+mustJSON(map[string]any{"error": map[string]any{"message": msg, "code": "rate_limit"}})+"\n\n")
+			errCode := "upstream_error"
+			if IsRateLimited(err) {
+				errCode = "rate_limit"
+			} else if IsAuthFailure(err) {
+				errCode = "auth_failure"
+			}
+			_ = sseRaw(r.Context(), w, flusher, "data: "+mustJSON(map[string]any{"error": map[string]any{"message": msg, "code": errCode}})+"\n\n")
 		}
 		pt := EstimateTokens(prompt)
 		ct := EstimateTokens(res.Text)
@@ -2027,6 +2045,9 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 	}
 	s.accountPool.MarkSuccess(acc.ID)
 	if body.Stream {
+		if body.SessionKey != "" {
+			s.sessions.upsert(conversation{ID: body.SessionKey, AccountID: acc.ID, ConversationID: res.ConversationID, SessionID: res.SessionID, Title: prompt})
+		}
 		if body.User != "" && res.ConversationID != "" {
 			s.userSessions.Put(body.User, res.ConversationID, res.SessionID, acc.ID)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1083,9 +1083,11 @@ func (s *Server) chatOnce(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		s.accountPool.MarkFailure(acc.ID, err, rateLimitCooldown)
-		writeUpstreamError(w, err)
-		return
+		if err != nil {
+			s.accountPool.MarkFailure(acc.ID, err, rateLimitCooldown)
+			writeUpstreamError(w, err)
+			return
+		}
 	}
 	s.accountPool.MarkSuccess(acc.ID)
 	res.Text = sanitizePublicAssistantText(res.Text)


### PR DESCRIPTION
7 个 agent 并行审查 6 个模块，逐函数深读代码后确认的 22 个真实 bug。无推测性改动，无功能删减。

## auth 模块 (5 bugs)

| # | Bug | 级别 | 文件 |
|---|-----|------|------|
| 1 | refreshInflight 失败路径用过期副本覆盖并发更新 | P1 | cache.go |
| 2 | device-code 账户 Refresh 用错 ClientID/endpoint | P1 | cache.go + token.go |
| 3 | EnsureValid TOCTOU — 过期快照覆盖并发 Upsert | P1 | cache.go |
| 4 | PollDeviceCode 未知 OAuth error 仍接受 access_token | P2 | device.go |
| 5 | Upsert fallback ID 秒级碰撞 | P2 | cache.go |

## web/server 核心 (7 bugs)

| # | Bug | 级别 | 文件 |
|---|-----|------|------|
| 6 | debug.go redactValue camelCase 键脱敏失效 | P1 | debug.go |
| 7 | openaiChat 流式路径未更新 SessionKey 会话存储 | P1 | server.go |
| 8 | keys.go update 持久化失败不回滚内存 | P1 | keys.go |
| 9 | validAPIKey \eyJ\ 前缀绕过鉴权 | P1 | server.go |
| 10 | 流式错误 SSE code 硬编码 rate_limit | P2 | server.go |
| 11 | 流式 + response_format 未 normalizeJSONText | P2 | server.go |
| 12 | bindProxy 解绑时清空全部 proxy 客户端缓存 | P2 | server.go |

## web/协议+工具 (3 bugs)

| # | Bug | 级别 | 文件 |
|---|-----|------|------|
| 13 | tool_calls delta 类型断言可 nil panic | P1 | protocol_handlers.go |
| 14 | gpt-5.6 reasoning 路由到 Gpt_5_5_Reasoning | P1 | codex_catalog.go |
| 15 | calls map 按连续索引迭代，非连续索引丢失 | P2 | protocol_handlers.go |

## web/账号安全会话 (7 bugs)

| # | Bug | 级别 | 文件 |
|---|-----|------|------|
| 16 | images.go url[:80] 越界 panic | P1 | images.go |
| 17 | deleteConversation 先删后查 | P1 | conversations.go |
| 18 | deploymentCheck 跨锁周期持有切片指针 | P1 | deployments.go |
| 19 | m365cloud OAuth refresh 请求体缺 URL 编码 | P1 | m365cloud.go |
| 20 | CleanupOldConversations 无时间戳检查误删 | P1 | m365cloud.go |
| 21 | imageGenerations 缺请求体大小限制 | P2 | images.go |
| 22 | conversation_manager Record 覆盖 CreatedAt | P2 | conversation_manager.go |

## mcp 模块 (7 bugs)

| # | Bug | 级别 | 文件 |
|---|-----|------|------|
| 23 | Connect() 死锁（mu 不可重入） | P0 | client.go |
| 24 | Session ID 提取失败（只匹配相对路径） | P0 | client.go |
| 25 | 请求/响应无 ID 关联，并发错乱 | P1 | client.go |
| 26 | sendRequest 忽略 HTTP 状态码 | P1 | client.go |
| 27 | Close() 未关闭 SSE 连接，goroutine 泄漏 | P1 | client.go |
| 28 | stdio.go 并发写入 stdin 无锁 | P1 | stdio.go |
| 29 | pool.go RoundTrip 无锁读 len(entries) | P2 | pool.go |

## 验证
- \go build ./...\ ✓
- \go vet ./...\ ✓
- \go test ./... -count=1\ ✓
- 16 files changed, +233/-100 lines
- 零功能删减，零推测性改动