### PR TITLE
fix: 6 critical P0 security and correctness bugs

### DIFF
--- a/internal/auth/cache.go
+++ b/internal/auth/cache.go
@@ -1,10 +1,11 @@
 package auth
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,6 +48,12 @@ type inflightRefresh struct {
 	done chan struct{}
 	acc  AccountToken
 	err  error
+}
+
+func cryptoRandUint16() uint16 {
+	var b [2]byte
+	_, _ = rand.Read(b[:])
+	return binary.BigEndian.Uint16(b[:])
 }
 
 func CachePath() string {
@@ -180,7 +187,7 @@ func (s *Store) Upsert(tok TokenSet) (AccountToken, error) {
 		id = tok.Email
 	}
 	if id == "" {
-		id = fmt.Sprintf("account-%s-%04x", time.Now().Format("150405"), rand.Intn(0x10000))
+		id = fmt.Sprintf("account-%s-%04x", time.Now().Format("150405"), cryptoRandUint16())
 	}
 	acc := AccountToken{
 		ID:           id,

--- a/internal/auth/device.go
+++ b/internal/auth/device.go
@@ -46,7 +46,7 @@ func StartDeviceCode() (DeviceCode, error) {
 		return DeviceCode{}, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return DeviceCode{}, err
 	}
@@ -90,7 +90,7 @@ func PollDeviceCode(deviceCode string) (TokenSet, bool, error) {
 		return TokenSet{}, false, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return TokenSet{}, false, err
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -64,8 +64,16 @@ func (r *toolRegistry) ClearTools() {
 // GlobalRegistry is a global registry of MCP sessions, keyed by session ID.
 var GlobalRegistry = &sessionRegistry{sessions: map[string]*session{}}
 
+// APIKeyValidator is injected by the web package to validate API keys.
+// When nil, no authentication is enforced on MCP endpoints.
+var APIKeyValidator func(r *http.Request) bool
+
 // HandleToolsList returns the currently registered tools as JSON. Mount at /v1/mcp/tools.
 func HandleToolsList(w http.ResponseWriter, r *http.Request) {
+	if APIKeyValidator != nil && !APIKeyValidator(r) {
+		http.Error(w, `{"error":{"message":"valid API key required","type":"auth_error"}}`, http.StatusUnauthorized)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	tools := GlobalToolRegistry.ListTools()

--- a/internal/web/account_health.go
+++ b/internal/web/account_health.go
@@ -46,12 +46,7 @@ func IsRateLimited(err error) bool {
 	if errors.As(err, &dialErr) {
 		return dialErr.Status == 429 || dialErr.Status == 503
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "429") ||
-		strings.Contains(msg, "too many requests") ||
-		strings.Contains(msg, "rate limit") ||
-		strings.Contains(msg, "limited") ||
-		strings.Contains(msg, "throttl")
+	return false
 }
 
 // IsAuthFailure reports whether err represents an upstream 401/403, meaning

--- a/internal/web/account_health_test.go
+++ b/internal/web/account_health_test.go
@@ -29,9 +29,9 @@ func TestUpstreamErrorClassification(t *testing.T) {
 		{&UpstreamHTTPError{Status: 403}, false, true, 0, http.StatusUnauthorized},
 		{&UpstreamHTTPError{Status: 502}, false, false, 0, http.StatusBadGateway},
 		{&UpstreamHTTPError{Status: 502, Body: "account is limited"}, true, false, 0, http.StatusTooManyRequests},
-		{fmt.Errorf("upstream http 429"), true, false, 0, http.StatusTooManyRequests},
-		{fmt.Errorf("Too many requests, slow down"), true, false, 0, http.StatusTooManyRequests},
-		{fmt.Errorf("account is limited"), true, false, 0, http.StatusTooManyRequests},
+		{fmt.Errorf("upstream http 429"), false, false, 0, http.StatusBadGateway},
+		{fmt.Errorf("Too many requests, slow down"), false, false, 0, http.StatusBadGateway},
+		{fmt.Errorf("account is limited"), false, false, 0, http.StatusBadGateway},
 		{fmt.Errorf("random failure"), false, false, 0, http.StatusBadGateway},
 		{chathub.ErrRateLimitNotice, true, false, 0, http.StatusTooManyRequests},
 	}
@@ -94,7 +94,7 @@ func TestCooldownExpiryClearsCallCount(t *testing.T) {
 	const id = "acct-expiry"
 	h.MarkCall(id)
 	h.MarkCall(id)
-	h.MarkFailure(id, fmt.Errorf("account limited"), time.Minute)
+	h.MarkFailure(id, &UpstreamHTTPError{Status: 429}, time.Minute)
 	h.mu.Lock()
 	h.cooldown[id] = time.Now().Add(-time.Second)
 	h.mu.Unlock()
@@ -108,7 +108,7 @@ func TestCooldownExpiryClearsCallCount(t *testing.T) {
 		t.Fatal("expired cooldown still marked limited")
 	}
 	h.MarkCall(id)
-	h.MarkFailure(id, fmt.Errorf("account limited"), time.Minute)
+	h.MarkFailure(id, &UpstreamHTTPError{Status: 429}, time.Minute)
 	h.mu.Lock()
 	h.cooldown[id] = time.Now().Add(-time.Second)
 	h.mu.Unlock()
@@ -116,7 +116,7 @@ func TestCooldownExpiryClearsCallCount(t *testing.T) {
 		t.Fatal("CooldownUntil must clear expired call count")
 	}
 	h.MarkCall(id)
-	h.MarkFailure(id, fmt.Errorf("account limited"), time.Minute)
+	h.MarkFailure(id, &UpstreamHTTPError{Status: 429}, time.Minute)
 	h.mu.Lock()
 	h.cooldown[id] = time.Now().Add(-time.Second)
 	h.mu.Unlock()
@@ -277,7 +277,7 @@ func TestAccountsReportsCooldown(t *testing.T) {
 	s := &Server{tokens: store, accountPool: newAccountHealth()}
 	s.accountPool.MarkCall("u-1")
 	s.accountPool.MarkCall("u-1")
-	s.accountPool.MarkFailure("u-1", fmt.Errorf("account limited"), 20*time.Minute)
+	s.accountPool.MarkFailure("u-1", &UpstreamHTTPError{Status: 429}, 20*time.Minute)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/api/accounts", nil)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -221,6 +221,7 @@ func (s *Server) RefreshExpiredTokens() {
 }
 
 func (s *Server) Routes() http.Handler {
+	mcp.APIKeyValidator = s.validAPIKey
 	m := http.NewServeMux()
 	m.HandleFunc("/api/admin/login", s.adminLogin)
 	m.HandleFunc("/api/admin/logout", s.adminLogout)
@@ -485,18 +486,14 @@ func (s *Server) validAPIKey(r *http.Request) bool {
 			raw = strings.TrimSpace(v[7:])
 		}
 	}
-	if raw != "" && s.apiKeys.valid(raw) {
-		return true
-	}
-	if strings.HasPrefix(raw, "eyJ") {
-		return true
-	}
-	return false
+	return raw != "" && s.apiKeys.valid(raw)
 }
 
 func jsonOut(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("[jsonOut] encode error: %v", err)
+	}
 }
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
3 agent全项目审查发现的P0安全和正确性问题。

1. eyJ前缀鉴权绕过 - server.go - 任何eyJ开头字符串直接放行
2. IsRateLimited字符串误判 - account_health.go - 用户消息含429即触发限流
3. jsonOut吞错误 - server.go - json编码错误被忽略
4. device.go OOM - device.go - 响应体无大小限制
5. MCP HandleToolsList无认证 - mcp/server.go
6. math/rand ID碰撞 - cache.go - 并发可碰撞

go build/vet/test全通过