### PR TITLE
fix: 16 P1 bugs — JSON errors, MCP concurrency, outbound retry, chathub goroutine, toolRefusal, connpool stop

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -85,7 +85,7 @@ func Refresh(refreshToken, clientID, tokenEndpoint string) (TokenSet, error) {
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 	form.Set("scope", Scope())
-	return requestTokenTenant(form, tokenEndpoint)
+	return requestTokenTenant(form, tokenEndpoint, "Refresh")
 }
 
 // RefreshWithScope redeems the same account refresh token for a separately
@@ -111,10 +111,10 @@ func ROPC(username, password string) (TokenSet, error) {
 	form.Set("username", username)
 	form.Set("password", password)
 	form.Set("scope", Scope())
-	return requestTokenTenant(form, Authority()+"/organizations/oauth2/v2.0/token")
+	return requestTokenTenant(form, Authority()+"/organizations/oauth2/v2.0/token", "ROPC")
 }
 
-func requestTokenTenant(form url.Values, endpoint string) (TokenSet, error) {
+func requestTokenTenant(form url.Values, endpoint string, caller string) (TokenSet, error) {
 	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return TokenSet{}, err
@@ -134,10 +134,10 @@ func requestTokenTenant(form url.Values, endpoint string) (TokenSet, error) {
 		return TokenSet{}, fmt.Errorf("decode token response: %w", err)
 	}
 	if tr.Error != "" {
-		return TokenSet{}, fmt.Errorf("ROPC %s: %s", tr.Error, tr.ErrorDesc)
+		return TokenSet{}, fmt.Errorf("%s %s: %s", caller, tr.Error, tr.ErrorDesc)
 	}
 	if tr.AccessToken == "" {
-		return TokenSet{}, fmt.Errorf("ROPC HTTP %d: empty access token", resp.StatusCode)
+		return TokenSet{}, fmt.Errorf("%s HTTP %d: empty access token", caller, resp.StatusCode)
 	}
 	set := TokenSet{
 		AccessToken:  tr.AccessToken,

--- a/internal/chathub/client.go
+++ b/internal/chathub/client.go
@@ -365,14 +365,18 @@ func (c *Client) chatWithHandlers(ctx context.Context, acc Account, req Request,
 		msg []byte
 		err error
 	}
-	for time.Now().Before(deadline) {
-		_ = conn.SetReadDeadline(time.Now().Add(90 * time.Second))
-		// ReadMessage 阻塞期间无法响应 ctx 取消，放入独立 goroutine 由 select 联动。
-		readCh := make(chan wsRead, 1)
-		go func() {
+	readCh := make(chan wsRead, 1)
+	go func() {
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(90 * time.Second))
 			_, msg, err := conn.ReadMessage()
 			readCh <- wsRead{msg: msg, err: err}
-		}()
+			if err != nil {
+				return
+			}
+		}
+	}()
+	for time.Now().Before(deadline) {
 		var read wsRead
 		select {
 		case <-ctx.Done():
@@ -610,7 +614,7 @@ func (c *Client) uploadAttachments(ctx context.Context, acc Account, conversatio
 			return fmt.Errorf("invalid image data URL")
 		}
 		encoded := imageData[comma+1:]
-		if strings.Contains(strings.ToLower(imageData[:comma]), ";base64") == false {
+		if !strings.Contains(strings.ToLower(imageData[:comma]), ";base64") {
 			return fmt.Errorf("image URL is not base64")
 		}
 		if _, err := base64.StdEncoding.DecodeString(encoded); err != nil {

--- a/internal/chathub/connpool.go
+++ b/internal/chathub/connpool.go
@@ -21,6 +21,7 @@ type ConnPool struct {
 	dialer  *websocket.Dialer
 	header  http.Header
 	baseURL string // pre-built URL without session/conversation IDs
+	stop    chan struct{}
 }
 
 func NewConnPool(dialer *websocket.Dialer, header http.Header) *ConnPool {
@@ -28,6 +29,7 @@ func NewConnPool(dialer *websocket.Dialer, header http.Header) *ConnPool {
 		conns:  make(map[string]*pooledConn),
 		dialer: dialer,
 		header: header,
+		stop:   make(chan struct{}),
 	}
 	go p.gcLoop()
 	return p
@@ -79,6 +81,16 @@ func (p *ConnPool) GC() {
 	}
 }
 
+func (p *ConnPool) Close() {
+	close(p.stop)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for k, pc := range p.conns {
+		pc.conn.Close()
+		delete(p.conns, k)
+	}
+}
+
 func (p *ConnPool) Stats() map[string]any {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -88,7 +100,12 @@ func (p *ConnPool) Stats() map[string]any {
 func (p *ConnPool) gcLoop() {
 	ticker := time.NewTicker(2 * time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		p.GC()
+	for {
+		select {
+		case <-p.stop:
+			return
+		case <-ticker.C:
+			p.GC()
+		}
 	}
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -9,11 +9,14 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // Client is an MCP client that connects to an MCP server via HTTP SSE.
 // It implements the MCP client protocol: discover tools, invoke tools.
+var nextRequestID int64
+
 type Client struct {
 	serverURL  string
 	httpClient *http.Client
@@ -51,12 +54,12 @@ func (c *Client) setConnected(v bool) {
 // Connect establishes the SSE connection to the MCP server and initializes the session.
 func (c *Client) Connect(ctx context.Context) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.connected {
+		c.mu.Unlock()
 		return nil
 	}
+	c.mu.Unlock()
 
-	// Establish SSE connection
 	sseURL := c.serverURL
 	if !strings.Contains(sseURL, "/sse") {
 		sseURL = strings.TrimRight(sseURL, "/") + "/sse"
@@ -76,8 +79,8 @@ func (c *Client) Connect(ctx context.Context) error {
 		return fmt.Errorf("sse status: %s", resp.Status)
 	}
 
-	// Parse the SSE response to get the session ID and endpoint
 	scanner := bufio.NewScanner(resp.Body)
+	var sessionID string
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "data: ") {
@@ -85,28 +88,31 @@ func (c *Client) Connect(ctx context.Context) error {
 			fmt.Printf("[mcp-client] sse data: %s\n", data)
 		}
 		if strings.HasPrefix(line, "event: endpoint") {
-			// Next line should contain the data with the message URL
 			continue
 		}
 		if strings.Contains(line, "sessionId=") {
 			data := strings.TrimPrefix(line, "data: ")
 			if idx := strings.Index(data, "sessionId="); idx >= 0 {
-				c.sessionID = data[idx+10:]
+				sessionID = data[idx+10:]
 			}
 			break
 		}
 	}
 
-	if c.sessionID == "" {
+	if sessionID == "" {
 		resp.Body.Close()
 		return fmt.Errorf("no session ID received from MCP server")
 	}
 
-	// Start background goroutine to read SSE events
 	sseCtx, cancel := context.WithCancel(ctx)
+
+	c.mu.Lock()
+	c.sessionID = sessionID
 	c.sseCancel = cancel
 	c.sseBody = resp.Body
 	c.connected = true
+	c.mu.Unlock()
+
 	go c.readSSE(resp.Body)
 
 	_, initCh, err := c.sendRequest(sseCtx, "initialize", map[string]any{
@@ -125,7 +131,6 @@ func (c *Client) Connect(ctx context.Context) error {
 		return fmt.Errorf("timeout waiting for initialize response")
 	}
 
-	// Send initialized notification
 	_ = c.sendNotification("notifications/initialized", nil)
 
 	return nil
@@ -226,7 +231,7 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments map[string
 }
 
 func (c *Client) sendRequest(ctx context.Context, method string, params any) (int64, chan json.RawMessage, error) {
-	id := time.Now().UnixNano()
+	id := atomic.AddInt64(&nextRequestID, 1)
 	req := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      id,
@@ -304,6 +309,10 @@ func (c *Client) Close() error {
 	body := c.sseBody
 	c.sseCancel = nil
 	c.sseBody = nil
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()

--- a/internal/outbound/pool.go
+++ b/internal/outbound/pool.go
@@ -160,6 +160,9 @@ func (t *poolRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	t.pool.mu.Lock()
 	n := len(t.pool.entries) + 1
 	t.pool.mu.Unlock()
+	if n > 3 {
+		n = 3
+	}
 	for i := 0; i < n; i++ {
 		next := t.pool.pick()
 		if next == nil || next == t.entry {

--- a/internal/web/account_health.go
+++ b/internal/web/account_health.go
@@ -244,10 +244,15 @@ func (h *accountHealth) ClearAllCooldowns() {
 func (h *accountHealth) EarliestRecovery() time.Time {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	earliest := time.Now().Add(5 * time.Minute)
+	if len(h.cooldown) == 0 {
+		return time.Time{}
+	}
+	var earliest time.Time
+	first := true
 	for _, until := range h.cooldown {
-		if until.Before(earliest) {
+		if first || until.Before(earliest) {
 			earliest = until
+			first = false
 		}
 	}
 	return earliest

--- a/internal/web/conversations.go
+++ b/internal/web/conversations.go
@@ -10,7 +10,7 @@ import (
 
 func (s *Server) conversations(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	jsonOut(w, map[string]any{"conversations": s.sessions.list()})
@@ -18,14 +18,14 @@ func (s *Server) conversations(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deleteConversation(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body struct {
 		ID string `json:"id"`
 	}
 	if json.NewDecoder(r.Body).Decode(&body) != nil || body.ID == "" {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	s.conversationManager.Delete(body.ID)
@@ -35,7 +35,7 @@ func (s *Server) deleteConversation(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) conversationCleanup(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body struct {
@@ -88,13 +88,13 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 			"status":          "active",
 		})
 	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 	}
 }
 
 func (s *Server) handleCacheStats(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	stats := cacheStats.GetStats()
@@ -107,7 +107,7 @@ func (s *Server) handleCacheStats(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCacheStatsReset(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	cacheStats.Reset()
@@ -116,7 +116,7 @@ func (s *Server) handleCacheStatsReset(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleM365Conversations(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	if m365CloudClient == nil && len(s.sessionResolver.ListSessions()) == 0 {
@@ -178,7 +178,7 @@ func (s *Server) handleM365Conversations(w http.ResponseWriter, r *http.Request)
 
 func (s *Server) handleM365ConversationDetail(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	conversationID := strings.TrimSpace(r.URL.Query().Get("id"))
@@ -244,7 +244,7 @@ func conversationTimestamp(row map[string]any) int64 {
 
 func (s *Server) handleM365Delete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	if m365CloudClient == nil {
@@ -255,7 +255,7 @@ func (s *Server) handleM365Delete(w http.ResponseWriter, r *http.Request) {
 		ConversationID string `json:"conversation_id"`
 	}
 	if json.NewDecoder(r.Body).Decode(&body) != nil || body.ConversationID == "" {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	if err := m365CloudClient.DeleteConversation(body.ConversationID); err != nil {
@@ -268,7 +268,7 @@ func (s *Server) handleM365Delete(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleM365Cleanup(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	if m365CloudClient == nil {
@@ -300,18 +300,18 @@ func (s *Server) handleM365Cleanup(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSessionDelete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	sessionID := strings.TrimPrefix(r.URL.Path, "/v1/sessions/")
 	if sessionID == "" {
-		http.Error(w, "session_id required", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "session_id required")
 		return
 	}
 	if s.sessionResolver.DeleteSession(sessionID) {
 		jsonOut(w, map[string]any{"status": "deleted", "session_id": sessionID})
 	} else {
-		http.Error(w, "session not found", http.StatusNotFound)
+		writeOpenAIError(w, http.StatusNotFound, "not_found", "session not found")
 	}
 }
 
@@ -322,12 +322,12 @@ type conversationWhitelistRequest struct {
 
 func (s *Server) conversationWhitelist(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body conversationWhitelistRequest
 	if json.NewDecoder(r.Body).Decode(&body) != nil || body.ConversationID == "" {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	if body.Add {

--- a/internal/web/debug.go
+++ b/internal/web/debug.go
@@ -223,5 +223,5 @@ func (s *Server) debugDetail(w http.ResponseWriter, r *http.Request) {
 		jsonOut(w, x)
 		return
 	}
-	http.Error(w, "not found", 404)
+	writeOpenAIError(w, http.StatusNotFound, "not_found", "not found")
 }

--- a/internal/web/images.go
+++ b/internal/web/images.go
@@ -49,13 +49,13 @@ type imageGenerationRequest struct {
 func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now()
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", 405)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var b imageGenerationRequest
 	r.Body = http.MaxBytesReader(w, r.Body, maxImageEditRequestBytes)
 	if json.NewDecoder(r.Body).Decode(&b) != nil || strings.TrimSpace(b.Prompt) == "" {
-		http.Error(w, `{"error":{"message":"prompt is required","type":"invalid_request_error"}}`, 400)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "prompt is required")
 		return
 	}
 	if b.N <= 0 {
@@ -70,7 +70,7 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 		format = "url"
 	}
 	if format != "url" && format != "b64_json" {
-		http.Error(w, `{"error":{"message":"response_format must be url or b64_json","type":"invalid_request_error"}}`, 400)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "response_format must be url or b64_json")
 		return
 	}
 	acc, err := s.resolveAccount(firstNonEmpty(b.AccountID, b.User))
@@ -138,7 +138,7 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 		debug := map[string]any{"text": textPreview, "raw_len": len(res.RawResult), "events": len(res.Events), "images": res.Images, "raw_preview": rawPreview}
 		b, _ := json.Marshal(debug)
 		log.Printf("[image-gen-debug] %s", string(b))
-		http.Error(w, `{"error":{"message":"upstream returned no image resource","type":"upstream_error"}}`, 502)
+		writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "upstream returned no image resource")
 		return
 	}
 	images := res.Images
@@ -153,7 +153,7 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 			if format == "b64_json" {
 				parts := strings.SplitN(sourceURL, ",", 2)
 				if len(parts) != 2 {
-					http.Error(w, `{"error":{"message":"invalid upstream image data","type":"upstream_error"}}`, 502)
+					writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "invalid upstream image data")
 					return
 				}
 				data = append(data, map[string]string{"b64_json": parts[1]})
@@ -164,7 +164,7 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 		}
 		if !isDesignerImageURL(sourceURL) {
 			if format == "b64_json" {
-				http.Error(w, `{"error":{"message":"upstream returned URL, not b64_json","type":"unsupported_response_format"}}`, 502)
+				writeOpenAIError(w, http.StatusBadGateway, "unsupported_response_format", "upstream returned URL, not b64_json")
 				return
 			}
 			data = append(data, map[string]string{"url": sourceURL})
@@ -173,14 +173,14 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 		if designerToken == "" {
 			designerToken, err = s.designerAccessToken(acc)
 			if err != nil {
-				http.Error(w, upstreamError(err), 502)
+				writeOpenAIError(w, http.StatusBadGateway, "upstream_error", upstreamError(err))
 				return
 			}
 		}
 		imageData, contentType, err := downloadDesignerImage(ctx, sourceURL, designerToken)
 		if err != nil {
 			log.Printf("[image-gen-download] err=%v", err)
-			http.Error(w, upstreamError(err), 502)
+			writeOpenAIError(w, http.StatusBadGateway, "upstream_error", upstreamError(err))
 			return
 		}
 		if format == "b64_json" {
@@ -400,7 +400,7 @@ func generatedImageURL(r *http.Request, id string) string {
 
 func (s *Server) generatedImageFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	id := strings.TrimPrefix(r.URL.Path, "/v1/images/files/")

--- a/internal/web/security_http.go
+++ b/internal/web/security_http.go
@@ -50,13 +50,13 @@ func (s *Server) rootPage(w http.ResponseWriter, r *http.Request) {
 	}
 	f, err := webContent.Open(name)
 	if err != nil {
-		http.Error(w, "web interface unavailable", http.StatusInternalServerError)
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "web interface unavailable")
 		return
 	}
 	defer f.Close()
 	st, err := f.Stat()
 	if err != nil {
-		http.Error(w, "web interface unavailable", http.StatusInternalServerError)
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "web interface unavailable")
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -294,14 +294,14 @@ func (s *Server) adminMiddleware(next http.Handler) http.Handler {
 		}
 		if strings.HasPrefix(r.URL.Path, "/v1/") {
 			if !s.validAPIKey(r) {
-				http.Error(w, `{"error":{"message":"valid API key required","type":"auth_error"}}`, http.StatusUnauthorized)
+				writeOpenAIError(w, http.StatusUnauthorized, "auth_error", "valid API key required")
 				return
 			}
 			next.ServeHTTP(w, r)
 			return
 		}
 		if s.adminPassword == "" {
-			http.Error(w, `{"error":{"message":"administrator password is not configured","type":"configuration_error"}}`, http.StatusServiceUnavailable)
+			writeOpenAIError(w, http.StatusServiceUnavailable, "configuration_error", "administrator password is not configured")
 			return
 		}
 		if !s.validAdminSession(r) {
@@ -430,7 +430,7 @@ func (s *Server) adminKeys(w http.ResponseWriter, r *http.Request) {
 			Name string `json:"name"`
 		}
 		if json.NewDecoder(r.Body).Decode(&b) != nil {
-			http.Error(w, "bad json", 400)
+			writeOpenAIError(w, 400, "invalid_request_error", "bad json")
 			return
 		}
 		if strings.TrimSpace(b.Name) == "" {
@@ -438,7 +438,7 @@ func (s *Server) adminKeys(w http.ResponseWriter, r *http.Request) {
 		}
 		rec, raw, e := s.apiKeys.create(b.Name)
 		if e != nil {
-			http.Error(w, e.Error(), 500)
+			writeOpenAIError(w, 500, "internal_error", e.Error())
 			return
 		}
 		jsonOut(w, map[string]any{"key": raw, "record": rec})
@@ -446,11 +446,11 @@ func (s *Server) adminKeys(w http.ResponseWriter, r *http.Request) {
 		id := r.URL.Query().Get("id")
 		deleted, e := s.apiKeys.delete(id)
 		if e != nil {
-			http.Error(w, e.Error(), http.StatusInternalServerError)
+			writeOpenAIError(w, http.StatusInternalServerError, "internal_error", e.Error())
 			return
 		}
 		if !deleted {
-			http.Error(w, "key not found", 404)
+			writeOpenAIError(w, 404, "not_found", "key not found")
 			return
 		}
 		jsonOut(w, map[string]string{"status": "deleted"})
@@ -461,21 +461,21 @@ func (s *Server) adminKeys(w http.ResponseWriter, r *http.Request) {
 			Revoked *bool  `json:"revoked"`
 		}
 		if json.NewDecoder(r.Body).Decode(&b) != nil || b.ID == "" {
-			http.Error(w, "bad json", 400)
+			writeOpenAIError(w, 400, "invalid_request_error", "bad json")
 			return
 		}
 		updated, e := s.apiKeys.update(b.ID, b.Name, b.Revoked)
 		if e != nil {
-			http.Error(w, e.Error(), http.StatusInternalServerError)
+			writeOpenAIError(w, http.StatusInternalServerError, "internal_error", e.Error())
 			return
 		}
 		if !updated {
-			http.Error(w, "key not found", 404)
+			writeOpenAIError(w, 404, "not_found", "key not found")
 			return
 		}
 		jsonOut(w, map[string]string{"status": "updated"})
 	default:
-		http.Error(w, "method not allowed", 405)
+		writeOpenAIError(w, 405, "invalid_request_error", "method not allowed")
 	}
 }
 func (s *Server) validAPIKey(r *http.Request) bool {
@@ -512,7 +512,7 @@ func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) accounts(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	list := s.tokens.List()
@@ -557,14 +557,14 @@ func (s *Server) accounts(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) refreshAccount(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body struct {
 		ID string `json:"id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.ID) == "" {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	acc, err := s.tokens.EnsureValid(strings.TrimSpace(body.ID))
@@ -580,7 +580,7 @@ func (s *Server) refreshAccount(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) scheduleAccount(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body struct {
@@ -588,11 +588,11 @@ func (s *Server) scheduleAccount(w http.ResponseWriter, r *http.Request) {
 		Enabled bool   `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.ID) == "" {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	if err := s.tokens.SetScheduleEnabled(strings.TrimSpace(body.ID), body.Enabled); err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		writeOpenAIError(w, http.StatusNotFound, "not_found", err.Error())
 		return
 	}
 	jsonOut(w, map[string]any{"status": "updated", "scheduleEnabled": body.Enabled})
@@ -638,7 +638,7 @@ func (s *Server) tokenHealth(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) clearCooldown(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	s.accountPool.ClearAllCooldowns()
@@ -647,18 +647,18 @@ func (s *Server) clearCooldown(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deleteAccount(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body struct {
 		ID string `json:"id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ID == "" {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	if err := s.tokens.Delete(body.ID); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeOpenAIError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 	jsonOut(w, map[string]string{"status": "deleted"})
@@ -666,7 +666,7 @@ func (s *Server) deleteAccount(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) provisionAccount(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	if !s.validAdminSession(r) {
@@ -678,7 +678,7 @@ func (s *Server) provisionAccount(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Email == "" || body.Password == "" {
-		http.Error(w, "email and password required", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "email and password required")
 		return
 	}
 	set, err := auth.ROPC(body.Email, body.Password)
@@ -699,7 +699,7 @@ func (s *Server) provisionAccount(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) bindProxy(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	if !s.validAdminSession(r) {
@@ -711,7 +711,7 @@ func (s *Server) bindProxy(w http.ResponseWriter, r *http.Request) {
 		ProxyURL string `json:"proxyUrl"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ID == "" {
-		http.Error(w, "id required", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "id required")
 		return
 	}
 	if body.ProxyURL != "" {
@@ -739,12 +739,12 @@ func (s *Server) bindProxy(w http.ResponseWriter, r *http.Request) {
 func (s *Server) startPKCE(w http.ResponseWriter, _ *http.Request) {
 	v, err := auth.Verifier()
 	if err != nil {
-		http.Error(w, "pkce failure", http.StatusInternalServerError)
+		writeOpenAIError(w, http.StatusInternalServerError, "internal_error", "pkce failure")
 		return
 	}
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		http.Error(w, "state failure", http.StatusInternalServerError)
+		writeOpenAIError(w, http.StatusInternalServerError, "internal_error", "state failure")
 		return
 	}
 	state := hex.EncodeToString(b)
@@ -771,7 +771,7 @@ func (s *Server) startPKCE(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) pkceStatus(w http.ResponseWriter, r *http.Request) {
 	state := r.URL.Query().Get("state")
 	if state == "" {
-		http.Error(w, "missing state", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "missing state")
 		return
 	}
 	s.mu.Lock()
@@ -812,7 +812,7 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if state == "" || (code == "" && oauthError == "") {
-		http.Error(w, "missing state or authorization result", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "missing state or authorization result")
 		return
 	}
 	s.mu.Lock()
@@ -822,12 +822,12 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 			delete(s.pkce, state)
 		}
 		s.mu.Unlock()
-		http.Error(w, "invalid or expired state", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid or expired state")
 		return
 	}
 	if p.Status != "pending" {
 		s.mu.Unlock()
-		http.Error(w, "authorization result already consumed", http.StatusConflict)
+		writeOpenAIError(w, http.StatusConflict, "invalid_request_error", "authorization result already consumed")
 		return
 	}
 	p.Status = "processing"
@@ -840,7 +840,7 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 		p.Error = oauthError
 		s.pkce[state] = p
 		s.mu.Unlock()
-		http.Error(w, "Microsoft authorization failed: "+oauthError, http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "auth_error", "Microsoft authorization failed: "+oauthError)
 		return
 	}
 	redirectURI := p.RedirectURI
@@ -855,7 +855,7 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 		p.Error = err.Error()
 		s.pkce[state] = p
 		s.mu.Unlock()
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "auth_error", err.Error())
 		return
 	}
 	acc, err := s.tokens.Upsert(tok)
@@ -865,7 +865,7 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 		p.Error = err.Error()
 		s.pkce[state] = p
 		s.mu.Unlock()
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeOpenAIError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 	s.mu.Lock()
@@ -1010,18 +1010,18 @@ func sseRaw(ctx context.Context, w http.ResponseWriter, f http.Flusher, payload 
 
 func (s *Server) chatOnce(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body chatBody
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	text := strings.TrimSpace(firstNonEmpty(body.Message, body.Prompt))
 	if text == "" && len(body.Attachments) == 0 {
-		http.Error(w, "message or attachment required", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "message or attachment required")
 		return
 	}
 	if body.SessionKey != "" {
@@ -1043,7 +1043,7 @@ func (s *Server) chatOnce(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if acc.OID == "" || acc.TID == "" {
-		http.Error(w, "account missing oid/tid — re-login with PKCE browser client", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "account_error", "account missing oid/tid — re-login with PKCE browser client")
 		return
 	}
 
@@ -1084,13 +1084,16 @@ func (s *Server) chatOnce(w http.ResponseWriter, r *http.Request) {
 					res = res2
 					err = nil
 				} else {
+					s.accountPool.MarkFailure(next.ID, err2, rateLimitCooldown)
 					err = err2
 				}
 			}
 		}
-		s.accountPool.MarkFailure(acc.ID, err, rateLimitCooldown)
-		writeUpstreamError(w, err)
-		return
+		if err != nil {
+			s.accountPool.MarkFailure(acc.ID, err, rateLimitCooldown)
+			writeUpstreamError(w, err)
+			return
+		}
 	}
 	s.accountPool.MarkSuccess(acc.ID)
 	res.Text = sanitizePublicAssistantText(res.Text)
@@ -1127,7 +1130,7 @@ func (s *Server) dropTransientConversation(conversationID string) {
 
 func (s *Server) adminModelSync(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	syncUpstreamTones()
@@ -1137,7 +1140,7 @@ func (s *Server) adminModelSync(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) adminModels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	jsonOut(w, map[string]any{"object": "list", "data": modelCatalog()})
@@ -1147,14 +1150,14 @@ func (s *Server) adminModels(w http.ResponseWriter, r *http.Request) {
 // （密钥加固后 list 不再返回 raw，前端无法再自行携带 key 调用 /v1 端点）。
 func (s *Server) adminModelTest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var b struct {
 		Model string `json:"model"`
 	}
 	if json.NewDecoder(r.Body).Decode(&b) != nil || strings.TrimSpace(b.Model) == "" {
-		http.Error(w, "bad json: model required", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json: model required")
 		return
 	}
 	acc, err := s.resolveAccount("")
@@ -1189,7 +1192,7 @@ func (s *Server) adminModelTest(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) openaiModels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	data := modelCatalog()
@@ -1387,18 +1390,18 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[req-trace] id=%s stage=http_return total_ms=%d", requestID, time.Since(startedAt).Milliseconds())
 	}()
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	const maxChatRequestBody = 10 << 20
 	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxChatRequestBody))
 	if err != nil {
-		http.Error(w, "read body", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "read body")
 		return
 	}
 	var body oaiReq
 	if err := json.Unmarshal(raw, &body); err != nil {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	responseFormat := body.ResponseFormat
@@ -1454,7 +1457,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if prompt == "" {
-		http.Error(w, "messages required", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "messages required")
 		return
 	}
 	if answer, ok := publicIdentityAnswer(body.Messages, body.Model); ok && responseFormat == nil {
@@ -1513,7 +1516,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if acc.OID == "" || acc.TID == "" {
-		http.Error(w, "account missing oid/tid", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "account_error", "account missing oid/tid")
 		return
 	}
 
@@ -1599,7 +1602,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 			s.dropTransientConversation(routeRes.ConversationID)
 		}
 		if routeErr != nil {
-			http.Error(w, "tool router: "+routeErr.Error(), http.StatusBadGateway)
+			writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "tool router: "+routeErr.Error())
 			return
 		}
 		calls, parsed := parseModelToolDecision(routeRes.Text, toolMaps, body.ToolChoice)
@@ -1640,7 +1643,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Connection", "keep-alive")
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			http.Error(w, "stream unsupported", http.StatusInternalServerError)
+			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "stream unsupported")
 			return
 		}
 		if err := sseRaw(r.Context(), w, flusher, ": connected\n\n"); err != nil {
@@ -1905,7 +1908,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 				calls, parsed = parseModelToolDecision(repairRes.Text, toolMaps, body.ToolChoice)
 			}
 			if !parsed {
-				http.Error(w, "model returned an invalid tool routing decision", http.StatusBadGateway)
+				writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "model returned an invalid tool routing decision")
 				return
 			}
 		}
@@ -1946,7 +1949,7 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 					return
 				}
 			}
-			http.Error(w, "model did not select a required tool after constrained retry", http.StatusBadGateway)
+			writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "model did not select a required tool after constrained retry")
 			return
 		}
 	}
@@ -1960,7 +1963,7 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 		w.Header().Set("X-Accel-Buffering", "no")
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			http.Error(w, "stream unsupported", http.StatusInternalServerError)
+			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "stream unsupported")
 			return
 		}
 		id := "chatcmpl-" + uuid.NewString()
@@ -2231,7 +2234,7 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 		w.Header().Set("Connection", "keep-alive")
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			http.Error(w, "stream unsupported", http.StatusInternalServerError)
+			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "stream unsupported")
 			return
 		}
 		// one-shot "stream" — emit full content then done
@@ -2335,11 +2338,11 @@ func (s *Server) writePublicIdentityChatResponse(w http.ResponseWriter, r *http.
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "stream unsupported", http.StatusInternalServerError)
-		return
-	}
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeOpenAIError(w, http.StatusInternalServerError, "server_error", "stream unsupported")
+			return
+		}
 	chunk := map[string]any{
 		"id":      id,
 		"object":  "chat.completion.chunk",

--- a/internal/web/sessions.go
+++ b/internal/web/sessions.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -35,7 +36,9 @@ func openSessionStore() *sessionStore {
 	s := &sessionStore{path: path, data: map[string]conversation{}}
 	s.persist = &persistStore{flush: s.flush}
 	if b, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(b, &s.data)
+		if err := json.Unmarshal(b, &s.data); err != nil {
+			log.Printf("[sessions] failed to unmarshal %s: %v", path, err)
+		}
 	}
 	return s
 }
@@ -121,7 +124,9 @@ func openUserSessionStore(ttl time.Duration) *userSessionStore {
 	s := &userSessionStore{path: path, data: map[string]userSession{}, ttl: ttl}
 	s.persist = &persistStore{flush: s.flush}
 	if b, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(b, &s.data)
+		if err := json.Unmarshal(b, &s.data); err != nil {
+			log.Printf("[user-sessions] failed to unmarshal %s: %v", path, err)
+		}
 	}
 	s.evictLocked()
 	return s

--- a/internal/web/stream.go
+++ b/internal/web/stream.go
@@ -13,18 +13,18 @@ import (
 
 func (s *Server) chatStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	var body chatBody
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 	if json.NewDecoder(r.Body).Decode(&body) != nil {
-		http.Error(w, "bad json", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "bad json")
 		return
 	}
 	text := strings.TrimSpace(firstNonEmpty(body.Message, body.Prompt))
 	if text == "" {
-		http.Error(w, "message required", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "message required")
 		return
 	}
 	if body.SessionKey != "" {
@@ -45,7 +45,7 @@ func (s *Server) chatStream(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if acc.OID == "" || acc.TID == "" {
-		http.Error(w, "account missing oid/tid", http.StatusBadRequest)
+		writeOpenAIError(w, http.StatusBadRequest, "account_error", "account missing oid/tid")
 		return
 	}
 
@@ -55,7 +55,7 @@ func (s *Server) chatStream(w http.ResponseWriter, r *http.Request) {
 		Text: text, Tone: body.Tone, ConversationID: body.ConversationID, SessionID: body.SessionID, Attachments: body.Attachments,
 	})
 	if err != nil {
-		http.Error(w, upstreamError(err), http.StatusBadGateway)
+		writeOpenAIError(w, http.StatusBadGateway, "upstream_error", upstreamError(err))
 		return
 	}
 	if body.SessionKey != "" {
@@ -69,7 +69,7 @@ func (s *Server) chatStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		http.Error(w, "stream unsupported", http.StatusInternalServerError)
+		writeOpenAIError(w, http.StatusInternalServerError, "server_error", "stream unsupported")
 		return
 	}
 	for i, event := range res.Normalized {

--- a/internal/web/tool_response.go
+++ b/internal/web/tool_response.go
@@ -74,6 +74,6 @@ func writeToolResponse(w http.ResponseWriter, id, model string, stream bool, sen
 		_ = sseSafeRaw(w, flusher, "data: [DONE]\n\n")
 		return nil
 	}
-	jsonOut(w, map[string]any{"id": id, "object": "chat.completion", "model": model, "choices": []any{map[string]any{"index": 0, "message": msg, "finish_reason": "tool_calls"}}, "m365": compatM365Metadata(res), "usage": map[string]any{"prompt_tokens": pt, "completion_tokens": ct, "total_tokens": pt + ct}})
+	jsonOut(w, map[string]any{"id": id, "object": "chat.completion", "created": time.Now().Unix(), "model": model, "choices": []any{map[string]any{"index": 0, "message": msg, "finish_reason": "tool_calls"}}, "m365": compatM365Metadata(res), "usage": map[string]any{"prompt_tokens": pt, "completion_tokens": ct, "total_tokens": pt + ct}})
 	return nil
 }

--- a/internal/web/toolloop.go
+++ b/internal/web/toolloop.go
@@ -166,50 +166,17 @@ func validateToolResult(messages []oaiMsg, known map[string]bool) error {
 var toolRefusalPatterns = []string{
 	"tools are not available",
 	"tool is not available",
-	"cannot access the Windows path",
-	"only provides Linux",
-	"只提供 Linux 容器",
-	"工具未暴露",
-	"工具不可用",
-	"没有可调用的",
-	"无法继续操作",
-	"will not pretend",
-	"will not fake",
-	"cannot fake",
-	"would be fabricated",
-	"cannot fabricate",
-	"refuse to fabricate",
 	"not actually registered",
 	"not actually available",
-	"not exposed in this",
 	"not available in this session",
-	"cannot execute on this platform",
-	"没有 Windows 执行接口",
-	"回复通道没有",
-	"没有执行接口",
-	"不会虚构",
-	"不会!转入",
-	"不会转入",
-	"execution environment has changed",
-	"执行环境已经切换",
-	"无法访问上一会话",
-	"/mnt/data",
-	"current execution environment has changed",
-	"linux sandbox",
-	"linux container",
-	"running in a container",
-	"cannot modify source code",
-	"没有连接到",
-	"Windows 执行接口",
-	"I can run that for you",
-	"running in sandbox",
-	"executing in sandbox",
-	"code interpreter",
-	"python sandbox",
-	"sandbox environment",
+	"工具不可用",
+	"工具未暴露",
 }
 
 func isToolRefusal(text string) bool {
+	if len(text) >= 200 {
+		return false
+	}
 	low := strings.ToLower(text)
 	for _, p := range toolRefusalPatterns {
 		if strings.Contains(low, strings.ToLower(p)) {

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bufio"
 	"encoding/json"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -49,7 +50,9 @@ func openUsageLog() *usageLog {
 	}
 	s := &usageLog{Path: p}
 	s.persist = &persistStore{flush: s.flush}
-	_ = os.MkdirAll(filepath.Dir(p), 0700)
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		log.Printf("[usage] MkdirAll failed: %v", err)
+	}
 	s.load()
 	return s
 }

--- a/internal/web/usage_http.go
+++ b/internal/web/usage_http.go
@@ -7,7 +7,7 @@ import (
 
 func (s *Server) adminUsage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	days := 7
@@ -24,7 +24,7 @@ func (s *Server) adminUsage(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) adminUsageLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeOpenAIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 		return
 	}
 	limit := 50


### PR DESCRIPTION
3 agent全项目审查发现的P1问题。

| # | Bug | 文件 |
|---|-----|------|
| 1 | 所有http.Error改为writeOpenAIError JSON格式 | server.go,conversations.go,images.go,security_http.go,stream.go,usage_http.go |
| 2 | 非流式tool_calls响应缺created字段 | tool_response.go |
| 3 | persist.go MkdirAll错误忽略 | usage.go |
| 4 | sessions.go JSON加载失败静默忽略 | sessions.go |
| 5 | chatOnce failover双重MarkFailure | server.go |
| 6 | EarliestRecovery无cooldown返回now+5min | account_health.go |
| 7 | MCP Connect持锁请求 | mcp/client.go |
| 8 | MCP Close不清理pending | mcp/client.go |
| 9 | MCP sendRequest ID并发冲突 | mcp/client.go |
| 10 | outbound RoundTrip重试无上限 | outbound/pool.go |
| 11 | chathub每帧启动goroutine | chathub/client.go |
| 12 | isImageURL == false可读性 | chathub/client.go |
| 13 | isToolRefusal误报风险高 | toolloop.go |
| 14 | ConnPool gcLoop无法停止 | chathub/connpool.go |

go build/vet/test全通过