### PR TITLE
fix(stream): preserve SSE flush and safe conversation reuse

### DIFF
--- a/internal/chathub/client.go
+++ b/internal/chathub/client.go
@@ -349,6 +349,14 @@ func (c *Client) ChatWithReasoning(ctx context.Context, acc Account, req Request
 	})
 }
 
+// A pre-warmed websocket is created with its own conversation/session IDs.
+// It is safe for a fresh first turn, whose IDs are also generated locally, but
+// not for continuing an existing upstream conversation. Microsoft can finish
+// such mismatched continuation requests immediately with no answer text.
+func shouldReusePooledConnection(req Request) bool {
+	return req.ConversationID == "" && req.SessionID == ""
+}
+
 func (c *Client) chatWithHandlers(ctx context.Context, acc Account, req Request, onDelta func(string) error, onEvent StreamHandler) (Result, error) {
 	startedAt := time.Now()
 	log.Printf("chathub timing start prompt_len=%d", len(req.Text))
@@ -387,7 +395,7 @@ func (c *Client) chatWithHandlers(ctx context.Context, acc Account, req Request,
 	var reused bool
 	phase = PhaseDial
 
-	if c.Pool != nil {
+	if c.Pool != nil && shouldReusePooledConnection(req) {
 		var poolErr error
 		conn, reused, poolErr = c.Pool.Take(ctx, acc.OID, acc.TID, wsURL)
 		if poolErr != nil {

--- a/internal/chathub/connpool_reuse_test.go
+++ b/internal/chathub/connpool_reuse_test.go
@@ -1,0 +1,12 @@
+package chathub
+
+import "testing"
+
+func TestConversationReuseRequiresFreshWebSocket(t *testing.T) {
+	if shouldReusePooledConnection(Request{ConversationID: "conv", SessionID: "sess"}) {
+		t.Fatal("continuing an existing conversation on a pre-warmed websocket can return an immediate empty completion")
+	}
+	if !shouldReusePooledConnection(Request{}) {
+		t.Fatal("fresh first-turn requests should remain eligible for the connection pool")
+	}
+}

--- a/internal/web/middleware_stream_test.go
+++ b/internal/web/middleware_stream_test.go
@@ -1,0 +1,37 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type flushCountingWriter struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func (w *flushCountingWriter) Flush() {
+	w.flushes++
+	w.ResponseRecorder.Flush()
+}
+
+func TestMiddlewareChainPreservesSSEFlush(t *testing.T) {
+	base := &flushCountingWriter{ResponseRecorder: httptest.NewRecorder()}
+	h := recoverPanics(httpTrace(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("middleware removed http.Flusher")
+		}
+		_, _ = w.Write([]byte("data: first\n\n"))
+		f.Flush()
+		_, _ = w.Write([]byte("data: second\n\n"))
+		f.Flush()
+	})))
+
+	h.ServeHTTP(base, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil))
+	if base.flushes != 2 {
+		t.Fatalf("underlying Flush called %d times, want 2", base.flushes)
+	}
+}

--- a/internal/web/recover.go
+++ b/internal/web/recover.go
@@ -26,6 +26,15 @@ func (w *streamingWriter) Write(b []byte) (int, error) {
 	return w.ResponseWriter.Write(b)
 }
 
+func (w *streamingWriter) Flush() {
+	if !w.headerWritten {
+		w.headerWritten = true
+	}
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // recoverPanics 捕获 handler panic，已开始流式时不写错误体，否则返回 JSON 500。
 func recoverPanics(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- preserve `http.Flusher` through the panic-recovery `ResponseWriter`, so `/v1/chat/completions` SSE chunks are flushed as they are produced instead of arriving together at completion
- only use pre-warmed WebSockets for fresh conversations; continuation requests now dial with their actual `ConversationID`/`SessionID`
- add regression tests for middleware flush propagation and continuation pooling eligibility

## Root causes

1. `recoverPanics` wraps the response with `streamingWriter`, but that wrapper did not implement `http.Flusher`. The inner streaming handler therefore lost flush support and Go buffered SSE frames until the handler returned.
2. Pre-warmed WebSockets are opened with randomly generated conversation/session IDs. Reusing one for a request that already has IDs can cause Microsoft to complete immediately with no text because the URL-bound IDs do not match the continuation request.

## Verification

- Before the middleware fix: `TestMiddlewareChainPreservesSSEFlush` reported `underlying Flush called 0 times, want 2`.
- Before the pooling fix: no continuation eligibility guard existed; production logs showed `reused=true (pooled)`, completion in about 44 ms, and `streamed_text=0` on the second turn.
- After the fixes: targeted regression tests pass.
- Full suite passes with:

```sh
apk add --no-cache python3
go test ./... -count=1
```

## Scope

The latest upstream `main` already includes API-key tenant isolation in #57, so this PR intentionally excludes the older local isolation patch and contains only the two still-missing runtime fixes.
