### PR TITLE
feat(auth): select accounts and disable Copilot memory

### DIFF
--- a/internal/auth/pkce.go
+++ b/internal/auth/pkce.go
@@ -31,5 +31,6 @@ func AuthorizationURL(endpoint, clientID, redirect, state, challenge, scope stri
 	q.Set("state", state)
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
+	q.Set("prompt", "select_account")
 	return fmt.Sprintf("%s?%s", endpoint, q.Encode())
 }

--- a/internal/auth/pkce_test.go
+++ b/internal/auth/pkce_test.go
@@ -14,7 +14,7 @@ func TestChallengeIsDeterministic(t *testing.T) {
 
 func TestAuthorizationURL(t *testing.T) {
 	u := AuthorizationURL("https://login.example/authorize", "client", "http://127.0.0.1/callback", "state", "challenge", "openid offline_access")
-	for _, want := range []string{"client_id=client", "state=state", "code_challenge=challenge", "code_challenge_method=S256", "scope=openid"} {
+	for _, want := range []string{"client_id=client", "state=state", "code_challenge=challenge", "code_challenge_method=S256", "scope=openid", "prompt=select_account"} {
 		if !contains(u, want) {
 			t.Fatalf("URL missing %q: %s", want, u)
 		}

--- a/internal/web/memory_handlers.go
+++ b/internal/web/memory_handlers.go
@@ -14,7 +14,9 @@ import (
 	"time"
 )
 
-const substrateBase = "https://substrate.office.com"
+var substrateBase = "https://substrate.office.com"
+
+var substrateHTTPClient = outbound.HTTPClient()
 
 var flagsCache = &struct {
 	sync.Mutex
@@ -22,12 +24,21 @@ var flagsCache = &struct {
 }{m: map[string]flagsCacheEntry{}}
 
 type flagsCacheEntry struct {
-	body     []byte
+	body      []byte
 	fetchedAt time.Time
 }
 
 func (s *Server) memoryAccount(r *http.Request) (auth.AccountToken, bool) {
-	acc, err := s.resolveAccount("")
+	accountID := strings.TrimSpace(r.URL.Query().Get("account_id"))
+	var (
+		acc auth.AccountToken
+		err error
+	)
+	if accountID != "" {
+		acc, err = s.tokens.EnsureValid(accountID)
+	} else {
+		acc, err = s.resolveAccount("")
+	}
 	if err != nil {
 		return auth.AccountToken{}, false
 	}
@@ -62,7 +73,7 @@ func proxySubstrate(w http.ResponseWriter, targetURL string, method string, acc 
 		return
 	}
 	req.Header = substrateHeaders(acc)
-	resp, err := outbound.HTTPClient().Do(req)
+	resp, err := substrateHTTPClient.Do(req)
 	if err != nil {
 		log.Printf("[memory-proxy] substrate error url=%s err=%v", targetURL, err)
 		writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "substrate request failed")
@@ -101,7 +112,7 @@ func (s *Server) memoryGetFlags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req.Header = substrateHeaders(acc)
-	resp, err := outbound.HTTPClient().Do(req)
+	resp, err := substrateHTTPClient.Do(req)
 	if err != nil {
 		log.Printf("[memory-flags] substrate error err=%v", err)
 		writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "substrate request failed")

--- a/internal/web/personalization.go
+++ b/internal/web/personalization.go
@@ -1,0 +1,80 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"m365-copilot2api/internal/auth"
+)
+
+const personalizationUserFlagsPath = "/m365Copilot/PersonalizationUserFlags?variants=feature.EnablePersonalization"
+
+type personalizationFlags struct {
+	IsMemoryEnabled                          bool `json:"isMemoryEnabled"`
+	IsCustomInstructionEnabled               bool `json:"isCustomInstructionEnabled"`
+	IsPersonalizationEnabledByTenant         bool `json:"isPersonalizationEnabledByTenant"`
+	IsInsightsFromConversationHistoryEnabled bool `json:"isInsightsFromConversationHistoryEnabled"`
+}
+
+func doSubstrateJSON(ctx context.Context, method, targetURL string, acc auth.AccountToken, body io.Reader, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, targetURL, body)
+	if err != nil {
+		return err
+	}
+	req.Header = substrateHeaders(acc)
+	resp, err := substrateHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("substrate endpoint returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("parse substrate response: %w", err)
+		}
+	}
+	return nil
+}
+
+func setPersonalizationMemory(ctx context.Context, acc auth.AccountToken, enabled bool) error {
+	payload, _ := json.Marshal(map[string]bool{"isMemoryEnabled": enabled})
+	return doSubstrateJSON(ctx, http.MethodPost, substrateBase+personalizationUserFlagsPath, acc, bytes.NewReader(payload), nil)
+}
+
+func readPersonalizationFlags(ctx context.Context, acc auth.AccountToken) (personalizationFlags, error) {
+	var flags personalizationFlags
+	err := doSubstrateJSON(ctx, http.MethodGet, substrateBase+personalizationUserFlagsPath, acc, nil, &flags)
+	return flags, err
+}
+
+func invalidatePersonalizationFlags(acc auth.AccountToken) {
+	flagsCache.Lock()
+	delete(flagsCache.m, acc.ID)
+	flagsCache.Unlock()
+}
+
+func disableAndVerifyMemory(ctx context.Context, acc auth.AccountToken) (personalizationFlags, error) {
+	if err := setPersonalizationMemory(ctx, acc, false); err != nil {
+		return personalizationFlags{}, err
+	}
+	invalidatePersonalizationFlags(acc)
+	flags, err := readPersonalizationFlags(ctx, acc)
+	if err != nil {
+		return personalizationFlags{}, err
+	}
+	if flags.IsMemoryEnabled || flags.IsInsightsFromConversationHistoryEnabled {
+		return flags, fmt.Errorf("memory disable did not take effect")
+	}
+	return flags, nil
+}

--- a/internal/web/personalization_test.go
+++ b/internal/web/personalization_test.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"m365-copilot2api/internal/auth"
+)
+
+func TestSetPersonalizationMemoryUsesSharedSubstrateLayer(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotAnchor, gotScenario string
+	var gotBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.RequestURI()
+		gotAuth = r.Header.Get("Authorization")
+		gotAnchor = r.Header.Get("X-AnchorMailbox")
+		gotScenario = r.Header.Get("X-Scenario")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"value":"Success"}}`))
+	}))
+	defer ts.Close()
+
+	oldBase := substrateBase
+	oldClient := substrateHTTPClient
+	substrateBase = ts.URL
+	substrateHTTPClient = ts.Client()
+	defer func() {
+		substrateBase = oldBase
+		substrateHTTPClient = oldClient
+	}()
+
+	acc := auth.AccountToken{AccessToken: "token", OID: "oid", TID: "tid"}
+	if err := setPersonalizationMemory(context.Background(), acc, false); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method=%s", gotMethod)
+	}
+	if gotPath != personalizationUserFlagsPath {
+		t.Fatalf("path=%s", gotPath)
+	}
+	if gotAuth != "Bearer token" {
+		t.Fatalf("authorization=%q", gotAuth)
+	}
+	if gotAnchor != "Oid:oid@tid" {
+		t.Fatalf("anchor=%q", gotAnchor)
+	}
+	if gotScenario != "OfficeWebIncludedCopilot" {
+		t.Fatalf("scenario=%q", gotScenario)
+	}
+	if enabled, ok := gotBody["isMemoryEnabled"].(bool); !ok || enabled {
+		t.Fatalf("body=%#v", gotBody)
+	}
+}
+
+func TestDisableAndVerifyMemoryInvalidatesFlagsCache(t *testing.T) {
+	requests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"isMemoryEnabled":false,"isInsightsFromConversationHistoryEnabled":false}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"result":{"value":"Success"}}`))
+	}))
+	defer ts.Close()
+	oldBase := substrateBase
+	oldClient := substrateHTTPClient
+	substrateBase = ts.URL
+	substrateHTTPClient = ts.Client()
+	defer func() { substrateBase, substrateHTTPClient = oldBase, oldClient }()
+
+	acc := auth.AccountToken{ID: "account", AccessToken: "token", OID: "oid", TID: "tid"}
+	flagsCache.Lock()
+	flagsCache.m[acc.ID] = flagsCacheEntry{body: []byte(`{"isMemoryEnabled":true}`), fetchedAt: time.Now()}
+	flagsCache.Unlock()
+	if _, err := disableAndVerifyMemory(context.Background(), acc); err != nil {
+		t.Fatal(err)
+	}
+	flagsCache.Lock()
+	_, cached := flagsCache.m[acc.ID]
+	flagsCache.Unlock()
+	if cached {
+		t.Fatal("flags cache retained stale pre-disable value")
+	}
+	if requests != 2 {
+		t.Fatalf("requests=%d want POST+GET", requests)
+	}
+}
+
+func TestMemoryAccountHonorsAccountID(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "accounts.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"first", "second"} {
+		if _, err := store.Upsert(auth.TokenSet{HomeOID: id, TenantID: "tenant", AccessToken: "token-" + id, Email: id + "@example.test", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &Server{tokens: store, accountPool: newAccountHealth(), accountConcurrency: newAccountConcurrency()}
+	r := httptest.NewRequest(http.MethodGet, "/v1/memory/flags?account_id=second", nil)
+	acc, ok := s.memoryAccount(r)
+	if !ok || acc.ID != "second" {
+		t.Fatalf("account=%#v ok=%t", acc, ok)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1020,9 +1020,20 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
+	memoryDisabled := false
+	memoryError := ""
+	memoryCtx, cancelMemory := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancelMemory()
+	if _, err := disableAndVerifyMemory(memoryCtx, acc); err != nil {
+		memoryError = err.Error()
+		log.Printf("[personalization] account=%s disable memory failed: %v", acc.Email, err)
+	} else {
+		memoryDisabled = true
+		log.Printf("[personalization] account=%s saved memory and history insights disabled", acc.Email)
+	}
 	s.mu.Lock()
 	p.Status = "authenticated"
-	p.Account = map[string]any{"id": acc.ID, "email": acc.Email, "displayName": acc.DisplayName, "status": acc.Status, "oid": acc.OID, "tid": acc.TID}
+	p.Account = map[string]any{"id": acc.ID, "email": acc.Email, "displayName": acc.DisplayName, "status": acc.Status, "oid": acc.OID, "tid": acc.TID, "memoryDisabled": memoryDisabled, "memoryError": memoryError}
 	s.pkce[state] = p
 	s.mu.Unlock()
 	// Browser loopback callbacks should finish in a friendly page instead of
@@ -1033,8 +1044,10 @@ func (s *Server) callbackPKCE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonOut(w, map[string]any{
-		"status":  "authenticated",
-		"account": map[string]any{"id": acc.ID, "email": acc.Email, "displayName": acc.DisplayName, "status": acc.Status, "oid": acc.OID, "tid": acc.TID},
+		"status":          "authenticated",
+		"memory_disabled": memoryDisabled,
+		"memory_error":    memoryError,
+		"account":         map[string]any{"id": acc.ID, "email": acc.Email, "displayName": acc.DisplayName, "status": acc.Status, "oid": acc.OID, "tid": acc.TID},
 	})
 }
 


### PR DESCRIPTION
## Summary

- add `prompt=select_account` to the Microsoft PKCE authorization URL so each import displays the account chooser instead of silently authorizing the browser's current Microsoft session
- after a successful account import, call the M365 `PersonalizationUserFlags` endpoint with `{"isMemoryEnabled":false}`
- read the flags back and verify both saved memory and conversation-history insights are disabled
- expose `memory_disabled` / `memory_error` in the manual callback response and PKCE status account metadata
- keep account import successful if the optional preference request fails, while logging and returning the failure instead of silently claiming success

## Motivation

A gateway commonly imports multiple Microsoft 365 accounts from one browser. Without `prompt=select_account`, Microsoft may reuse the active login session and add the wrong account with no login/account-selection step.

These accounts are also shared upstream identities for API traffic. M365 Copilot saved memory and conversation-history insights are account-level personalization settings, so leaving them enabled can allow one API user's content to influence later users routed through the same upstream account.

## Endpoint verified

```http
POST https://substrate.office.com/m365Copilot/PersonalizationUserFlags?variants=feature.EnablePersonalization
Content-Type: application/json

{"isMemoryEnabled":false}
```

The implementation then verifies with GET. A successful disabled state has:

```json
{
  "isMemoryEnabled": false,
  "isInsightsFromConversationHistoryEnabled": false
}
```

The request uses the account's freshly issued Sydney access token and the same account-routing headers used by the M365 web client. No new OAuth scope or stored credential is introduced.

## Tests

- PKCE authorization URL includes `prompt=select_account`
- disable request method, path, bearer token, account headers, scenario, and JSON body
- personalization flag response parsing
- full suite:

```sh
apk add --no-cache python3
go test ./... -count=1
```

All packages pass.

## Notes

`PersonalizationUserFlags` is an upstream browser endpoint rather than a documented stable public API. The account import is therefore not rolled back if the preference call fails; the failure is visible via callback/status metadata and logs.
