### PR TITLE
fix(mcp): implement missing MCP resources API + endpoint auth on the pending-channel client (port of #48)

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -139,7 +140,7 @@ func (c *Client) Connect(ctx context.Context) error {
 func (c *Client) readSSE(body io.ReadCloser) {
 	defer body.Close()
 	defer c.setConnected(false)
-	
+
 	scanner := bufio.NewScanner(body)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -156,6 +157,14 @@ func (c *Client) readSSE(body io.ReadCloser) {
 					select {
 					case ch <- json.RawMessage(data):
 					default:
+						// Non-blocking send is correct in the per-request
+						// channel model: each pending channel has capacity 1
+						// and exactly one consumer select-waiting on it. A
+						// full channel therefore means the requester already
+						// timed out and unregistered — blocking here would
+						// stall the SSE reader for a response nobody will
+						// ever read.
+						log.Printf("[mcp] dropping late SSE response for id %d (requester gone or timed out)", *meta.ID)
 					}
 				}
 			}
@@ -248,7 +257,7 @@ func (c *Client) sendRequest(ctx context.Context, method string, params any) (in
 	c.mu.Unlock()
 
 	messageURL := fmt.Sprintf("%s/message?sessionId=%s", strings.TrimRight(strings.Split(c.serverURL, "/sse")[0], "/"), c.sessionID)
-	
+
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, messageURL, strings.NewReader(string(body)))
 	if err != nil {
 		c.mu.Lock()
@@ -286,7 +295,7 @@ func (c *Client) sendNotification(method string, params any) error {
 	body, _ := json.Marshal(req)
 
 	messageURL := fmt.Sprintf("%s/message?sessionId=%s", strings.TrimRight(strings.Split(c.serverURL, "/sse")[0], "/"), c.sessionID)
-	
+
 	httpReq, err := http.NewRequest(http.MethodPost, messageURL, strings.NewReader(string(body)))
 	if err != nil {
 		return err

--- a/internal/mcp/client_sse_test.go
+++ b/internal/mcp/client_sse_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type nopCloser struct{ *strings.Reader }
+
+func (n *nopCloser) Close() error { return nil }
+
+// TestReadSSEDropsLateResponseWithoutBlocking verifies that readSSE never
+// stalls on a full per-request channel: once the requester has timed out and
+// gone, the late response must be dropped immediately so the SSE reader keeps
+// draining the HTTP body. This pins the non-blocking-send semantics of the
+// pending map model (regression guard against reintroducing a blocking send,
+// which deadlocks the whole SSE session when no waiter ever arrives).
+func TestReadSSEDropsLateResponseWithoutBlocking(t *testing.T) {
+	c := NewClient("http://unused")
+	// Simulate a stale requester: registered channel, already full, nobody reading.
+	stale := make(chan json.RawMessage, 1)
+	stale <- json.RawMessage(`{"stale":true}`)
+	c.mu.Lock()
+	c.pending[7] = stale
+	c.mu.Unlock()
+
+	body := "data: {\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{}}\n\n"
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.readSSE(&nopCloser{Reader: strings.NewReader(body)})
+	}()
+
+	select {
+	case <-done:
+		c.mu.Lock()
+		_, still := c.pending[7]
+		c.mu.Unlock()
+		if !still {
+			t.Fatal("readSSE must not unregister pending entries")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readSSE blocked on a full channel: unbounded blocking send regression")
+	}
+}
+
+// TestReadSSEDeliversToWaiter verifies the happy path: a response whose
+// requester is actively waiting receives it via its per-request channel.
+func TestReadSSEDeliversToWaiter(t *testing.T) {
+	c := NewClient("http://unused")
+	ch := make(chan json.RawMessage, 1)
+	c.mu.Lock()
+	c.pending[42] = ch
+	c.mu.Unlock()
+
+	body := "data: {\"jsonrpc\":\"2.0\",\"id\":42,\"result\":{\"ok\":true}}\n\n"
+	go c.readSSE(&nopCloser{Reader: strings.NewReader(body)})
+
+	select {
+	case got := <-ch:
+		if !strings.Contains(string(got), `"ok":true`) {
+			t.Fatalf("unexpected payload: %s", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for response delivery")
+	}
+}
+
+// TestReadSSESkipsNotifications verifies messages without an id (server
+// notifications) are consumed without touching any pending entry.
+func TestReadSSESkipsNotifications(t *testing.T) {
+	c := NewClient("http://unused")
+	body := "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{}}\n\n"
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.readSSE(&nopCloser{Reader: strings.NewReader(body)})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readSSE hung on a notification without id")
+	}
+}
+
+var (
+	_ = bufio.NewScanner
+	_ = httptest.NewRecorder
+	_ = context.Background
+)

--- a/internal/mcp/resources_ssrf_test.go
+++ b/internal/mcp/resources_ssrf_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestResourcesReadRejectsUnlistedURI verifies the SSRF guard: only URIs
+// advertised by ListResources may be read, even when they use an allowed scheme.
+func TestResourcesReadRejectsUnlistedURI(t *testing.T) {
+	orig := resourceProvider()
+	SetGlobalResourceProvider(&stubResourceProvider{
+		resources: []Resource{{URI: "m365://safe/one", Name: "Safe One", MIMEType: "text/plain"}},
+		content: map[string]ResourceContent{
+			"m365://internal/secret": {URI: "m365://internal/secret", Text: "top secret"},
+			"m365://safe/one":        {URI: "m365://safe/one", Text: "hello"},
+		},
+	})
+	defer SetGlobalResourceProvider(orig)
+
+	GlobalRegistry = &sessionRegistry{sessions: map[string]*session{}}
+	sessID := GlobalRegistry.RegisterSession(nil)
+
+	read := func(uri string) string {
+		w := httptest.NewRecorder()
+		body := `{"jsonrpc":"2.0","id":9,"method":"resources/read","params":{"uri":"` + uri + `"}}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/mcp/message?sessionId="+sessID, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		HandleMessage(w, req)
+		sess := GlobalRegistry.getSession(sessID)
+		select {
+		case msg := <-sess.msgCh:
+			return string(msg)
+		case <-req.Context().Done():
+			t.Fatal("timeout")
+		}
+		return ""
+	}
+
+	if out := read("m365://internal/secret"); !strings.Contains(out, "-32002") {
+		t.Fatalf("unlisted URI was readable: %s", out)
+	}
+	if out := read("file:///etc/passwd"); !strings.Contains(out, "-32602") {
+		t.Fatalf("disallowed scheme accepted: %s", out)
+	}
+	out := read("m365://safe/one")
+	var resp struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil || !strings.Contains(string(resp.Result), "hello") {
+		t.Fatalf("listed URI should be readable, got: %s", out)
+	}
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type stubResourceProvider struct {
+	resources []Resource
+	content   map[string]ResourceContent
+}
+
+func (s *stubResourceProvider) ListResources(ctx context.Context) ([]Resource, error) {
+	return s.resources, nil
+}
+
+func (s *stubResourceProvider) ReadResource(ctx context.Context, uri string) (ResourceContent, error) {
+	if c, ok := s.content[uri]; ok {
+		return c, nil
+	}
+	return ResourceContent{}, errUnknownResource(uri)
+}
+
+type errUnknownResource string
+
+func (e errUnknownResource) Error() string { return "unknown resource: " + string(e) }
+
+func TestResourcesListReturnsRegisteredResources(t *testing.T) {
+	orig := resourceProvider()
+	SetGlobalResourceProvider(&stubResourceProvider{
+		resources: []Resource{
+			{URI: "m365://test/foo", Name: "Test Foo", MIMEType: "text/plain"},
+		},
+	})
+	defer SetGlobalResourceProvider(orig)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/mcp/message?sessionId=test-rsrc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"resources/list"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	GlobalRegistry = &sessionRegistry{sessions: map[string]*session{}}
+	sessID := GlobalRegistry.RegisterSession(nil)
+	req.URL.RawQuery = "sessionId=" + sessID
+
+	HandleMessage(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status %d", w.Code)
+	}
+
+	sess := GlobalRegistry.getSession(sessID)
+	select {
+	case msg := <-sess.msgCh:
+		var resp struct {
+			Result json.RawMessage `json:"result"`
+		}
+		if err := json.Unmarshal(msg, &resp); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(resp.Result), "m365://test/foo") {
+			t.Fatalf("missing resource URI in result: %s", resp.Result)
+		}
+	case <-req.Context().Done():
+		t.Fatal("timeout")
+	}
+}
+
+func TestResourcesReadReturnsContent(t *testing.T) {
+	orig := resourceProvider()
+	SetGlobalResourceProvider(&stubResourceProvider{
+		resources: []Resource{{URI: "m365://test/bar", Name: "Test Bar", MIMEType: "application/json"}},
+		content: map[string]ResourceContent{
+			"m365://test/bar": {URI: "m365://test/bar", MIMEType: "application/json", Text: `{"ok":true}`},
+		},
+	})
+	defer SetGlobalResourceProvider(orig)
+
+	GlobalRegistry = &sessionRegistry{sessions: map[string]*session{}}
+	sessID := GlobalRegistry.RegisterSession(nil)
+
+	w := httptest.NewRecorder()
+	body := `{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"m365://test/bar"}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/mcp/message?sessionId="+sessID, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	HandleMessage(w, req)
+
+	sess := GlobalRegistry.getSession(sessID)
+	select {
+	case msg := <-sess.msgCh:
+		if !strings.Contains(string(msg), "test/bar") || !strings.Contains(string(msg), "ok") {
+			t.Fatalf("missing content in response: %s", msg)
+		}
+	case <-req.Context().Done():
+		t.Fatal("timeout")
+	}
+}
+
+func TestInitializeAdvertisesResourcesCapability(t *testing.T) {
+	GlobalRegistry = &sessionRegistry{sessions: map[string]*session{}}
+	sessID := GlobalRegistry.RegisterSession(nil)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/mcp/message?sessionId="+sessID, strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	HandleMessage(w, req)
+
+	sess := GlobalRegistry.getSession(sessID)
+	select {
+	case msg := <-sess.msgCh:
+		if !strings.Contains(string(msg), `"resources"`) {
+			t.Fatalf("initialize response missing resources capability: %s", msg)
+		}
+	case <-req.Context().Done():
+		t.Fatal("timeout")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -64,6 +65,29 @@ func (r *toolRegistry) ClearTools() {
 // GlobalRegistry is a global registry of MCP sessions, keyed by session ID.
 var GlobalRegistry = &sessionRegistry{sessions: map[string]*session{}}
 
+// globalResourceProvider is guarded by its own RWMutex: handleRPC runs on
+// per-request goroutines while registration paths (and tests) may swap the
+// provider concurrently. Access it only through resourceProvider() and
+// SetGlobalResourceProvider().
+var globalResourceProvider struct {
+	mu       sync.RWMutex
+	provider ResourceProvider
+}
+
+func resourceProvider() ResourceProvider {
+	globalResourceProvider.mu.RLock()
+	defer globalResourceProvider.mu.RUnlock()
+	return globalResourceProvider.provider
+}
+
+// SetGlobalResourceProvider installs the resource provider used by
+// resources/list and resources/read. Safe for concurrent use.
+func SetGlobalResourceProvider(p ResourceProvider) {
+	globalResourceProvider.mu.Lock()
+	defer globalResourceProvider.mu.Unlock()
+	globalResourceProvider.provider = p
+}
+
 // APIKeyValidator is injected by the web package to validate API keys.
 // When nil, no authentication is enforced on MCP endpoints.
 var APIKeyValidator func(r *http.Request) bool
@@ -90,12 +114,12 @@ type sessionRegistry struct {
 }
 
 type session struct {
-	id       string
+	id         string
 	providerMu sync.RWMutex
-	provider ToolProvider
-	created  time.Time
-	msgCh    chan json.RawMessage
-	done     chan struct{}
+	provider   ToolProvider
+	created    time.Time
+	msgCh      chan json.RawMessage
+	done       chan struct{}
 }
 
 // RegisterSession creates a new MCP session with the given tool provider and returns the session ID.
@@ -131,6 +155,10 @@ func (r *sessionRegistry) getSession(id string) *session {
 
 // HandleSSE handles MCP SSE connections. Mount at /v1/mcp/sse.
 func HandleSSE(w http.ResponseWriter, r *http.Request) {
+	if APIKeyValidator != nil && !APIKeyValidator(r) {
+		http.Error(w, `{"error":{"message":"valid API key required","type":"auth_error"}}`, http.StatusUnauthorized)
+		return
+	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
@@ -173,6 +201,10 @@ func HandleSSE(w http.ResponseWriter, r *http.Request) {
 
 // HandleMessage handles MCP JSON-RPC messages. Mount at /v1/mcp/message.
 func HandleMessage(w http.ResponseWriter, r *http.Request) {
+	if APIKeyValidator != nil && !APIKeyValidator(r) {
+		http.Error(w, `{"error":{"message":"valid API key required","type":"auth_error"}}`, http.StatusUnauthorized)
+		return
+	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -254,8 +286,11 @@ func handleRPC(ctx context.Context, sess *session, req *jsonRPCRequest) *jsonRPC
 	case "initialize":
 		return jsonRPCResult(req.ID, map[string]any{
 			"protocolVersion": "2024-11-05",
-			"capabilities":    map[string]any{"tools": map[string]any{}},
-			"serverInfo":      map[string]any{"name": "m365-copilot2api", "version": "0.1.0"},
+			"capabilities": map[string]any{
+				"tools":     map[string]any{},
+				"resources": map[string]any{"subscribe": false, "listChanged": false},
+			},
+			"serverInfo": map[string]any{"name": "m365-copilot2api", "version": "0.1.0"},
 		})
 	case "tools/list":
 		// First check session-specific tools, then fall back to global registry
@@ -298,6 +333,78 @@ func handleRPC(ctx context.Context, sess *session, req *jsonRPCRequest) *jsonRPC
 			})
 		}
 		return jsonRPCResult(req.ID, result)
+	case "resources/list":
+		if rp := resourceProvider(); rp != nil {
+			resources, err := rp.ListResources(ctx)
+			if err != nil {
+				// Forwarding err.Error() can leak internal details (paths,
+				// connection strings). Log it server-side and return a
+				// generic message instead.
+				log.Printf("[mcp] resources/list failed: %v", err)
+				return newRPCError(req.ID, -32603, "internal error: unable to list resources")
+			}
+			if resources == nil {
+				resources = []Resource{}
+			}
+			return jsonRPCResult(req.ID, map[string]any{"resources": resources})
+		}
+		return jsonRPCResult(req.ID, map[string]any{"resources": []Resource{}})
+	case "resources/read":
+		var params struct {
+			URI string `json:"uri"`
+		}
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			// The raw unmarshal error can echo request bytes / internal
+			// shapes; log it and return a generic message (consistent with
+			// the provider-error handling above and below).
+			log.Printf("[mcp] resources/read: invalid params: %v", err)
+			return newRPCError(req.ID, -32602, "invalid params: uri is required")
+		}
+		if params.URI == "" {
+			return newRPCError(req.ID, -32602, "missing uri")
+		}
+		if !strings.HasPrefix(params.URI, "mcp://") && !strings.HasPrefix(params.URI, "gateway://") && !strings.HasPrefix(params.URI, "m365://") {
+			return newRPCError(req.ID, -32602, "unsupported uri scheme: allowed prefixes are mcp://, gateway://, m365://")
+		}
+		rp := resourceProvider()
+		if rp == nil {
+			return newRPCError(req.ID, -32603, "no resources available")
+		}
+		// SSRF guard: a URI prefix check alone is not enough — an allowed
+		// scheme can still point at internal data. Only URIs the provider
+		// itself advertised via resources/list are readable, so reads are
+		// tied to the enumerated surface and cannot probe arbitrary targets.
+		//
+		// TODO(perf): this is O(n) per read. Fine at current resource
+		// counts; if providers grow large, add a ResourceExists(ctx, uri)
+		// method to ResourceProvider so the check happens inside the
+		// provider without materializing the list.
+		listed, err := rp.ListResources(ctx)
+		if err != nil {
+			log.Printf("[mcp] resources/read allowlist check failed: %v", err)
+			return newRPCError(req.ID, -32603, "internal error: unable to read resource")
+		}
+		allowed := false
+		for _, res := range listed {
+			if res.URI == params.URI {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			// Do not echo the requested URI back to the client — log it
+			// server-side instead.
+			log.Printf("[mcp] resources/read rejected unlisted uri %q", params.URI)
+			return newRPCError(req.ID, -32002, "resource not found")
+		}
+		content, err := rp.ReadResource(ctx, params.URI)
+		if err != nil {
+			log.Printf("[mcp] resources/read %q failed: %v", params.URI, err)
+			return newRPCError(req.ID, -32603, "internal error: unable to read resource")
+		}
+		return jsonRPCResult(req.ID, map[string]any{
+			"contents": []ResourceContent{content},
+		})
 	case "notifications/initialized":
 		return nil
 	default:

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"sync"
@@ -10,6 +11,25 @@ type Tool struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	InputSchema map[string]any `json:"inputSchema,omitempty"`
+}
+
+type Resource struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty"`
+}
+
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MIMEType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     []byte `json:"blob,omitempty"`
+}
+
+type ResourceProvider interface {
+	ListResources(ctx context.Context) ([]Resource, error)
+	ReadResource(ctx context.Context, uri string) (ResourceContent, error)
 }
 
 type CallResult struct {


### PR DESCRIPTION
## Summary

Port of #48 onto the current `main`, as requested in the last review round (the old branch targeted `dev` before the `msgCh → pending map[int64]chan` client refactor and no longer applied).

Supersedes #48.

### 1. MCP resources API was never implemented

Ports the implementation, adapted to main:

- `Resource` / `ResourceContent` / `ResourceProvider` types
- RWMutex-guarded global provider accessed only via `resourceProvider()` / `SetGlobalResourceProvider()` — safe for concurrent swap
- `resources/list` + `resources/read` handlers; `initialize` now advertises the `resources` capability
- **SSRF guard**: URI scheme allowlist (`mcp://`, `gateway://`, `m365://`) **plus** a check that the URI was actually advertised by `resources/list`, so reads are tied to the enumerated surface and cannot probe arbitrary targets. A `TODO(perf)` documents that the O(n) scan is acceptable at current scale, with `ResourceExists(ctx, uri)` as the future escape hatch.

### 2. Error-message hygiene

- Provider errors and raw JSON unmarshal errors are logged server-side; clients receive generic messages
- `resources/read` 404 (-32002) no longer echoes the requested URI back to the client — it is logged instead

### 3. Endpoint auth unified on `APIKeyValidator`

`HandleSSE` and `HandleMessage` now enforce `APIKeyValidator` — the same variable `HandleToolsList` already uses, wired once in `Routes()`. No new hook variable or `initMCPAuth`; the old `AuthHook` design from #48 is gone.

### 4. readSSE on the new per-request channel model

The original PR's bounded-blocking-send (timer reuse) is intentionally **not** ported: in the `pending map[int64]chan` model each channel has capacity 1 with exactly one select-waiting consumer, so a full channel means the requester already timed out. Blocking there would stall the SSE reader for a response nobody will ever read. The drop path now logs why.

The session_resolver reverse-index work from #48 is dropped: main's `Tenant`/`ExplicitID` refactor already handles `byExplicit` cleanup correctly.

## Testing

```
go build ./...
go vet ./internal/...
go test ./internal/...        # all pass
go test -race ./internal/mcp/ # pass
```

New/ported tests:
- `TestResourcesListReturnsRegisteredResources`, `TestResourcesReadReturnsContent`, `TestInitializeAdvertisesResourcesCapability`
- `TestResourcesReadRejectsUnlistedURI` (SSRF: unlisted-but-allowed-scheme rejected, disallowed scheme rejected, listed URI readable)
- `client_sse_test.go` rewritten for the pending model: late response drops without blocking, waiter delivery works, id-less notifications are skipped
