### PR TITLE
fix: 图片生成配额耗尽时自动跨账号轮换

### DIFF
--- a/internal/web/agent_ledger.go
+++ b/internal/web/agent_ledger.go
@@ -102,7 +102,12 @@ func buildAgentLedger(messages []oaiMsg) agentLedger {
 			l.RepeatedCall = true
 			l.RepetitionSignature = sig
 		}
-		if seenCall[sig] >= 3 {
+		// A repeated *successful* call is often legitimate agent behavior
+		// (re-reading a file, polling a status), so it must not trip the stuck
+		// guard at the old threshold of 3 — that produced false 409s. Only an
+		// extreme run of identical calls (>=5) is treated as a runaway loop.
+		// Repeated *failures* are handled separately below with a tighter bound.
+		if seenCall[sig] >= 5 {
 			l.StuckLoop = true
 		}
 		if e.Result == "" {
@@ -116,6 +121,9 @@ func buildAgentLedger(messages []oaiMsg) agentLedger {
 					l.RepeatedFailure = true
 					l.RepetitionSignature = fs
 				}
+				// The same call failing repeatedly is a genuine stuck loop:
+				// retrying an unchanged call that keeps erroring makes no
+				// progress, so cut it off at 3.
 				if seenFailure[fs] >= 3 {
 					l.StuckLoop = true
 				}

--- a/internal/web/agent_ledger_test.go
+++ b/internal/web/agent_ledger_test.go
@@ -57,6 +57,47 @@ func TestAgentLedgerDetectsRepeatedCallAndRoundLimit(t *testing.T) {
 	}
 }
 
+// A repeated but *successful* call must not trip the stuck-loop guard: agents
+// legitimately re-read files or poll a status without it being a runaway loop.
+// This is the false-positive that produced spurious 409 tool_round_limit
+// responses before the threshold was raised and gated on failure.
+func TestAgentLedgerSuccessfulRepeatsDoNotTripStuckLoop(t *testing.T) {
+	var msgs []oaiMsg
+	for i := 0; i < 4; i++ {
+		id := fmt.Sprintf("c%d", i)
+		msgs = append(msgs,
+			oaiMsg{Role: "assistant", ToolCalls: []map[string]any{{"id": id, "type": "function", "function": map[string]any{"name": "read_file", "arguments": "{\"path\":\"a.go\"}"}}}},
+			oaiMsg{Role: "tool", ToolCallID: id, Content: "package main"},
+		)
+	}
+	l := buildAgentLedger(msgs)
+	if l.StuckLoop {
+		t.Fatalf("successful repeats must not be a stuck loop: %+v", l)
+	}
+	if err := l.CanContinue(16); err != nil {
+		t.Fatalf("successful repeats blocked: %v", err)
+	}
+}
+
+// Repeated *failing* calls are a genuine stuck loop and must be cut off.
+func TestAgentLedgerRepeatedFailureTripsStuckLoop(t *testing.T) {
+	var msgs []oaiMsg
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("c%d", i)
+		msgs = append(msgs,
+			oaiMsg{Role: "assistant", ToolCalls: []map[string]any{{"id": id, "type": "function", "function": map[string]any{"name": "run", "arguments": "{\"cmd\":\"build\"}"}}}},
+			oaiMsg{Role: "tool", ToolCallID: id, Content: "exit code 1: failed"},
+		)
+	}
+	l := buildAgentLedger(msgs)
+	if !l.StuckLoop {
+		t.Fatalf("3 identical failures should be a stuck loop: %+v", l)
+	}
+	if err := l.CanContinue(16); err == nil {
+		t.Fatal("expected stuck loop / repeated failure error")
+	}
+}
+
 func TestActiveMessagesIgnoresOlderToolHistory(t *testing.T) {
 	var msgs []oaiMsg
 	for i := 0; i < 20; i++ {

--- a/internal/web/fenced_illustrative_test.go
+++ b/internal/web/fenced_illustrative_test.go
@@ -1,0 +1,48 @@
+package web
+
+import "testing"
+
+// A shell code block embedded in a long explanatory answer is an illustrative
+// example, not an execution request. Converting it to a tool call replaced the
+// whole prose answer with content:nil, so the client saw a truncated reply
+// while the upstream conversation held the full text. See the socks5 proxy
+// explanation regression.
+func TestFencedIllustrativeShellIsNotHijacked(t *testing.T) {
+	tools := []map[string]any{{"type": "function", "function": map[string]any{"name": "bash"}}}
+	prose := "你正在使用的 URL 是一个订阅链接。\n\n" +
+		"SOCKS5 代理是一种在传输层工作的通用代理协议，它不理解 HTTP 语义，" +
+		"因此可以转发任意 TCP/UDP 流量。相比之下 HTTP 代理只能代理 HTTP(S) 请求。\n\n" +
+		"下面是一个用 curl 走 SOCKS5 代理的例子：\n\n" +
+		"```bash\ncurl --proxy \"socks5h://user:pass@1.2.3.4:1080\" https://api.ipify.org\n```\n\n" +
+		"其中 socks5h 表示让代理服务器做 DNS 解析。总结：两者的核心区别在于协议层级和可代理的流量类型，" +
+		"SOCKS5 更通用，HTTP 代理更专用于网页请求。"
+	calls := fencedToolCalls(prose, tools, "auto")
+	if len(calls) != 0 {
+		t.Fatalf("illustrative shell block must not become a tool call, got %d: %+v", len(calls), calls)
+	}
+}
+
+// A short "run this" answer with minimal surrounding prose is still a genuine
+// execution request and must convert.
+func TestFencedShortShellStillConverts(t *testing.T) {
+	tools := []map[string]any{{"type": "function", "function": map[string]any{"name": "bash"}}}
+	calls := fencedToolCalls("Sure:\n```bash\nls -la\n```", tools, "auto")
+	if len(calls) != 1 || calls[0].Name != "bash" {
+		t.Fatalf("short execution request should convert, got %+v", calls)
+	}
+}
+
+// Explicit ```toolname\n{json}``` blocks are unambiguous structured calls and
+// must convert regardless of surrounding prose length.
+func TestFencedExplicitToolBlockConvertsWithLongProse(t *testing.T) {
+	tools := []map[string]any{{"type": "function", "function": map[string]any{"name": "workspace_shell"}}}
+	long := ""
+	for i := 0; i < 60; i++ {
+		long += "这是一段很长的解释文字用来撑过阈值。"
+	}
+	text := long + "\n```workspace_shell\n{\"command\":\"pwd\"}\n```\n" + long
+	calls := fencedToolCalls(text, tools, "auto")
+	if len(calls) != 1 || calls[0].Name != "workspace_shell" {
+		t.Fatalf("explicit tool block should convert despite long prose, got %+v", calls)
+	}
+}

--- a/internal/web/fenced_tools.go
+++ b/internal/web/fenced_tools.go
@@ -8,6 +8,18 @@ import (
 
 var fencedToolCall = regexp.MustCompile("(?s)```([A-Za-z0-9_-]+)\\s*\\n(.*?)\\n```")
 
+// illustrativeProseLimit is the amount of natural-language text (outside any
+// fenced block) beyond which a bare ```bash/sh/...``` block is treated as an
+// illustrative example rather than an execution request. A genuine "run this"
+// answer from the upstream model carries little surrounding prose; a normal
+// chat answer that merely quotes a shell command carries a lot. Without this
+// guard an explanatory answer containing a code sample was converted into a
+// tool call and its entire prose body was discarded (content:nil), so the
+// client saw a truncated / empty reply while the upstream conversation held
+// the full text. The limit is measured in runes so CJK answers (which are
+// byte-dense but rune-compact) are judged fairly.
+const illustrativeProseLimit = 120
+
 // declaredShell returns the shell-ish tool name the client actually
 // declared (bash/sh/shell/powershell/cmd), or "" if none. Forcing an
 // undeclared bash call on clients that don't support it (issue #12) makes
@@ -21,9 +33,21 @@ func declaredShell(allowed map[string]bool) string {
 	return ""
 }
 
+// proseOutsideFences returns the length in runes of the text left after all
+// fenced code blocks are removed. It measures how much explanatory prose
+// surrounds the code, which distinguishes an example from an execution intent.
+func proseOutsideFences(text string) int {
+	stripped := fencedToolCall.ReplaceAllString(text, "")
+	return len([]rune(strings.TrimSpace(stripped)))
+}
+
 func fencedToolCalls(text string, tools []map[string]any, choice any) []detectedToolCall {
 	allowed := allowedToolNames(tools)
 	shell := declaredShell(allowed)
+	// A shell code block wrapped in a long prose answer is an illustration, not
+	// a command to run. Explicit ```toolname\n{json}``` blocks (where the fence
+	// language is the declared tool name) stay unambiguous and are unaffected.
+	illustrative := proseOutsideFences(text) > illustrativeProseLimit
 	var out []detectedToolCall
 	for _, m := range fencedToolCall.FindAllStringSubmatch(text, -1) {
 		name := m[1]
@@ -33,6 +57,13 @@ func fencedToolCalls(text string, tools []map[string]any, choice any) []detected
 		// Auto-convert bash/shell code blocks to tool calls, but only when
 		// the client declared the tool.
 		if name == "bash" || name == "sh" || name == "shell" || name == "powershell" || name == "cmd" {
+			// A shell block embedded in a long explanatory answer is a quoted
+			// example, not a command to execute. Skip conversion so the prose
+			// answer is delivered intact instead of being replaced by an
+			// (unwanted) tool call with content:nil.
+			if illustrative {
+				continue
+			}
 			converted := name
 			if !allowed[name] {
 				if shell == "" {
@@ -64,7 +95,7 @@ func fencedToolCalls(text string, tools []map[string]any, choice any) []detected
 		out = append(out, detectedToolCall{ID: callID(name, string(b), len(out)), Type: toolType(name, tools), Name: name, Arguments: b})
 	}
 	// Also check for plain JSON objects with a "command" field (not in fenced blocks)
-	if len(out) == 0 && shell != "" {
+	if len(out) == 0 && shell != "" && !illustrative {
 		for i := 0; i < len(text); i++ {
 			if text[i] != '{' {
 				continue

--- a/internal/web/images.go
+++ b/internal/web/images.go
@@ -73,18 +73,6 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "response_format must be url or b64_json")
 		return
 	}
-	acc, err := s.resolveAccount(firstNonEmpty(b.AccountID, b.User))
-	if err != nil {
-		writeUpstreamError(w, err)
-		return
-	}
-	if acc.OID == "" || acc.TID == "" {
-		acc.OID, acc.TID = extractOIDTID(acc.AccessToken)
-	}
-	if acc.OID == "" || acc.TID == "" {
-		writeOpenAIError(w, 400, "invalid_request_error", "account missing oid/tid — re-login with PKCE")
-		return
-	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(s.settings.get().ImageTimeoutSeconds)*time.Second)
 	defer cancel()
 	size := b.Size
@@ -101,44 +89,115 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 		endpoint = "/v1/images/edits"
 		prompt = fmt.Sprintf("Edit the first attached image with GPT Image 2. Size: %s. Instructions: %s. Preserve everything not requested to change. Return the edited image URL directly.", size, b.Prompt)
 	}
-	res, err := s.chatWithAccount(ctx, acc.ID, chathub.Account{AccessToken: acc.AccessToken, OID: acc.OID, TID: acc.TID}, chathub.Request{Text: prompt, Tone: "magic", Attachments: b.Attachments, LicenseType: s.settings.get().LicenseType, Scenario: s.settings.get().Scenario, FeatureFlags: s.featureFlags()})
-	if err != nil {
-		writeUpstreamError(w, err)
-		return
+
+	// Image generation resolves and runs against a single account. When the
+	// upstream refuses with a quota message the model still returns 0 images;
+	// that account is out of image quota, so mark it image-limited (24h) and
+	// try the next healthy account instead of failing immediately. A caller
+	// who pins a specific account (AccountID/User) is not rotated.
+	pinned := firstNonEmpty(b.AccountID, b.User)
+	var acc auth.AccountToken
+	var res chathub.Result
+	var lastRefusal string
+	tried := map[string]bool{}
+	attempts := 1
+	if pinned == "" {
+		attempts = maxAccountProbe
 	}
-	log.Printf("[image-gen] conversation=%s images=%d text_len=%d events=%d raw_len=%d", res.ConversationID, len(res.Images), len(res.Text), len(res.Events), len(res.RawResult))
-	if len(res.Images) == 0 {
-		if urls := extractImageURLs(res.RawResult); len(urls) > 0 {
-			res.Images = urls
+	quotaExhausted := false
+	for i := 0; i < attempts; i++ {
+		var err error
+		if pinned != "" {
+			acc, err = s.resolveAccount(pinned)
+		} else if i == 0 {
+			acc, err = s.resolveAccount("")
+		} else {
+			acc, err = s.nextHealthyAccount(acc.ID)
 		}
-	}
-	if len(res.Images) == 0 {
-		if urls := extractImageURLs(res.Text); len(urls) > 0 {
-			res.Images = urls
+		if err != nil {
+			if i == 0 {
+				writeUpstreamError(w, err)
+				return
+			}
+			break
 		}
-	}
-	if len(res.Images) == 0 {
-		refusalText := strings.Join([]string{res.Text, res.RawResult}, "\n")
+		if tried[acc.ID] {
+			continue
+		}
+		tried[acc.ID] = true
+		if pinned == "" && !s.accountPool.ImageGenAvailable(acc.ID) {
+			// Skip accounts already known to be image-limited/cooling down.
+			continue
+		}
+		if acc.OID == "" || acc.TID == "" {
+			acc.OID, acc.TID = extractOIDTID(acc.AccessToken)
+		}
+		if acc.OID == "" || acc.TID == "" {
+			if pinned != "" {
+				writeOpenAIError(w, 400, "invalid_request_error", "account missing oid/tid — re-login with PKCE")
+				return
+			}
+			continue
+		}
+		r0, gerr := s.chatWithAccount(ctx, acc.ID, chathub.Account{AccessToken: acc.AccessToken, OID: acc.OID, TID: acc.TID}, chathub.Request{Text: prompt, Tone: "magic", Attachments: b.Attachments, LicenseType: s.settings.get().LicenseType, Scenario: s.settings.get().Scenario, FeatureFlags: s.featureFlags()})
+		if gerr != nil {
+			s.accountPool.MarkFailure(acc.ID, gerr, s.getRateLimitCooldown())
+			if pinned != "" {
+				writeUpstreamError(w, gerr)
+				return
+			}
+			continue
+		}
+		log.Printf("[image-gen] account=%s conversation=%s images=%d text_len=%d events=%d raw_len=%d attempt=%d", acc.ID, r0.ConversationID, len(r0.Images), len(r0.Text), len(r0.Events), len(r0.RawResult), i+1)
+		if len(r0.Images) == 0 {
+			if urls := extractImageURLs(r0.RawResult); len(urls) > 0 {
+				r0.Images = urls
+			}
+		}
+		if len(r0.Images) == 0 {
+			if urls := extractImageURLs(r0.Text); len(urls) > 0 {
+				r0.Images = urls
+			}
+		}
+		if len(r0.Images) > 0 {
+			res = r0
+			break
+		}
+		// No images: distinguish quota exhaustion (rotate) from a generic empty.
+		refusalText := strings.Join([]string{r0.Text, r0.RawResult}, "\n")
 		if isImageQuotaRefusal(refusalText) {
-			w.Header().Set("Retry-After", "86400")
-			writeOpenAIError(w, http.StatusTooManyRequests, "rate_limit_error", "M365 image generation quota is exhausted; try again later or use another account")
-			return
+			quotaExhausted = true
+			lastRefusal = refusalText
+			s.accountPool.MarkImageLimited(acc.ID)
+			log.Printf("[image-gen] account=%s image quota exhausted, rotating", acc.ID)
+			if pinned != "" {
+				break
+			}
+			continue
 		}
-		textPreview := res.Text
+		// Generic empty (not a quota message) is not retryable across accounts.
+		textPreview := r0.Text
 		if len(textPreview) > 500 {
 			textPreview = textPreview[:500]
 		}
-		rawPreview := ""
-		if len(res.RawResult) > 0 {
-			rawPreview = res.RawResult
-			if len(rawPreview) > 500 {
-				rawPreview = rawPreview[:500]
-			}
+		rawPreview := r0.RawResult
+		if len(rawPreview) > 500 {
+			rawPreview = rawPreview[:500]
 		}
-		debug := map[string]any{"text": textPreview, "raw_len": len(res.RawResult), "events": len(res.Events), "images": res.Images, "raw_preview": rawPreview}
-		b, _ := json.Marshal(debug)
-		log.Printf("[image-gen-debug] %s", string(b))
+		debug := map[string]any{"text": textPreview, "raw_len": len(r0.RawResult), "events": len(r0.Events), "images": r0.Images, "raw_preview": rawPreview}
+		dbg, _ := json.Marshal(debug)
+		log.Printf("[image-gen-debug] %s", string(dbg))
 		writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "upstream returned no image resource")
+		return
+	}
+	if len(res.Images) == 0 {
+		if quotaExhausted {
+			_ = lastRefusal
+			w.Header().Set("Retry-After", "86400")
+			writeOpenAIError(w, http.StatusTooManyRequests, "rate_limit_error", "all accounts' image generation quota is exhausted; try again later")
+			return
+		}
+		writeOpenAIError(w, http.StatusBadGateway, "upstream_error", "no image-capable account available")
 		return
 	}
 	images := res.Images
@@ -171,9 +230,10 @@ func (s *Server) imageGenerations(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if designerToken == "" {
-			designerToken, err = s.designerAccessToken(acc)
-			if err != nil {
-				writeOpenAIError(w, http.StatusBadGateway, "upstream_error", upstreamError(err))
+			var derr error
+			designerToken, derr = s.designerAccessToken(acc)
+			if derr != nil {
+				writeOpenAIError(w, http.StatusBadGateway, "upstream_error", upstreamError(derr))
 				return
 			}
 		}

--- a/internal/web/images_rotate_test.go
+++ b/internal/web/images_rotate_test.go
@@ -1,0 +1,27 @@
+package web
+
+import "testing"
+
+// When an account's upstream refuses image generation with a quota message,
+// the gateway marks it image-limited so future requests fail over to another
+// account instead of hammering the exhausted one.
+func TestMarkImageLimitedBlocksAvailability(t *testing.T) {
+	h := newAccountHealth()
+	if h.ImageLimited("acc-1") {
+		t.Fatal("fresh account should not be image-limited")
+	}
+	h.MarkImageLimited("acc-1")
+	if !h.ImageLimited("acc-1") {
+		t.Fatal("MarkImageLimited must flag the account")
+	}
+	// MarkImageLimited also puts the account into general cooldown so the
+	// scheduler skips it.
+	if h.Available("acc-1") {
+		t.Fatal("image-limited account must be in cooldown / unavailable")
+	}
+	// An unrelated account is unaffected.
+	if h.ImageLimited("acc-2") || !h.Available("acc-2") {
+		t.Fatal("unrelated account should remain available")
+	}
+}
+

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/google/uuid"
 )
@@ -1813,6 +1812,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[mcp] tools=%d mcp_gateway=%s", len(toolMaps), mcpServerURL)
 	}
 	validateCalls := func(stage string, calls []detectedToolCall) ([]detectedToolCall, int) {
+		calls = dedupeToolCalls(calls)
 		valid, rejected := validateDetectedToolCalls(calls, toolMaps, body.ToolChoice)
 		for _, call := range rejected {
 			log.Printf("[tool-validation] id=%s stage=%s rejected_name=%q reason=%q", requestID, stage, call.Name, call.Reason)
@@ -1950,54 +1950,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 			if ev.Kind != "text" || ev.Text == "" {
 				return nil
 			}
-			text.WriteString(ev.Text)
-			pending.WriteString(ev.Text)
-			v := pending.String()
-			// Detect fenced code blocks (tool calls) that must not be emitted as text.
-			// They will be caught by fencedToolCalls after the stream completes.
-			if strings.Contains(v, "```bash") || strings.Contains(v, "\"command\"") {
-				return nil
-			}
-			// If we see an opening ```, buffer until the closing ``` or until we're sure it's not a tool call.
-			if i := strings.Index(v, "```"); i >= 0 {
-				after := v[i+3:]
-				// If there's a closing ```, emit everything up to and including the block.
-				if j := strings.Index(after, "```"); j >= 0 {
-					closeIdx := i + 3 + j + 3
-					if err := emitText(v[:i]); err != nil {
-						return err
-					}
-					pending.Reset()
-					pending.WriteString(v[i:closeIdx])
-					return nil
-				}
-				// Opening ``` without closing yet: emit everything before it, keep the fence buffered.
-				if err := emitText(v[:i]); err != nil {
-					return err
-				}
-				pending.Reset()
-				pending.WriteString(v[i:])
-				return nil
-			}
-			// No fence detected: emit immediately with a small tail buffer for fence detection.
-			// This replaces the old 8-rune threshold with a 3-rune buffer (enough to detect "```").
-			if runeCount := utf8.RuneCountInString(v); runeCount > 3 {
-				cut := 0
-				seen := 0
-				for i := range v {
-					if seen == runeCount-3 {
-						cut = i
-						break
-					}
-					seen++
-				}
-				if err := emitText(v[:cut]); err != nil {
-					return err
-				}
-				pending.Reset()
-				pending.WriteString(v[cut:])
-			}
-			return nil
+			return streamEmitText(ev, &text, &pending, emitText)
 		})
 		if err != nil && text.Len() == 0 && len(streamedTools) == 0 && !convReused && body.AccountID == "" && (body.ConversationID == "" || body.ConversationID == resolvedConversationID) && (IsRateLimited(err) || IsAuthFailure(err)) {
 			originalErr := err
@@ -2023,37 +1976,7 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 					if ev.Kind != "text" || ev.Text == "" {
 						return nil
 					}
-					text.WriteString(ev.Text)
-					pending.WriteString(ev.Text)
-					v := pending.String()
-					if strings.Contains(v, "```bash") || strings.Contains(v, "\"command\"") {
-						return nil
-					}
-					if i := strings.Index(v, "```"); i >= 0 {
-						if err := emitText(v[:i]); err != nil {
-							return err
-						}
-						pending.Reset()
-						pending.WriteString(v[i:])
-						return nil
-					}
-					if runeCount := utf8.RuneCountInString(v); runeCount > 8 {
-						cut := 0
-						seen := 0
-						for i := range v {
-							if seen == runeCount-8 {
-								cut = i
-								break
-							}
-							seen++
-						}
-						if err := emitText(v[:cut]); err != nil {
-							return err
-						}
-						pending.Reset()
-						pending.WriteString(v[cut:])
-					}
-					return nil
+					return streamEmitText(ev, &text, &pending, emitText)
 				})
 				if err2 == nil {
 					s.accountPool.MarkFailure(acc.ID, originalErr, s.getRateLimitCooldown())

--- a/internal/web/stream_text.go
+++ b/internal/web/stream_text.go
@@ -1,0 +1,96 @@
+package web
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"m365-copilot2api/internal/chathub"
+)
+
+// toolFenceMarkers are the fence openings that may become a tool call and must
+// therefore be withheld from the text stream until post-stream extraction runs.
+// Everything else (```text, ```json, ```mermaid, prose diagrams, ...) is normal
+// assistant output and must be emitted, otherwise legitimate answers get
+// truncated at the first code block.
+var toolFenceMarkers = []string{"```bash", "```sh", "```shell", "```powershell", "```cmd"}
+
+func hasToolFenceCandidate(v string) bool {
+	for _, m := range toolFenceMarkers {
+		if strings.Contains(v, m) {
+			return true
+		}
+	}
+	// A bare {"command": ...} object (shell code emitted without a fence) is
+	// also a tool-call candidate handled by fencedToolCalls after the stream.
+	return strings.Contains(v, "\"command\"")
+}
+
+// streamEmitText incrementally forwards assistant text during streaming while
+// correctly distinguishing tool-call fences from ordinary fenced content.
+//
+// Tool-candidate fences (```bash/sh/shell/powershell/cmd or a bare
+// {"command":...} object) are withheld so post-stream extraction can convert
+// them into tool calls. Any other completed fenced block — e.g. a ```text
+// diagram — is emitted as normal text. Only an unclosed trailing fence (and a
+// short tail used for fence detection) stays buffered in pending.
+//
+// Previously every fenced block was buffered and only the final pending value
+// was flushed, which dropped ```text blocks and the prose between them; that
+// truncated answers at the first code block.
+func streamEmitText(ev chathub.StreamEvent, text, pending *strings.Builder, emitText func(string) error) error {
+	text.WriteString(ev.Text)
+	pending.WriteString(ev.Text)
+	v := pending.String()
+
+	// Withhold the whole buffer while a tool-candidate fence is present; the
+	// post-stream fencedToolCalls pass decides whether it becomes a tool call
+	// or is flushed back as text (illustrative example).
+	if hasToolFenceCandidate(v) {
+		return nil
+	}
+
+	// Emit every complete, non-tool fenced block together with the prose
+	// around it. Stop at an unclosed fence and keep it buffered.
+	for {
+		i := strings.Index(v, "```")
+		if i < 0 {
+			break
+		}
+		j := strings.Index(v[i+3:], "```")
+		if j < 0 {
+			if err := emitText(v[:i]); err != nil {
+				return err
+			}
+			pending.Reset()
+			pending.WriteString(v[i:])
+			return nil
+		}
+		closeIdx := i + 3 + j + 3
+		if err := emitText(v[:closeIdx]); err != nil {
+			return err
+		}
+		v = v[closeIdx:]
+	}
+
+	// No unclosed fence remains. Emit everything except a short tail so a fence
+	// that is still arriving byte-by-byte ("`", "``", "```") can be detected on
+	// the next delta.
+	if runeCount := utf8.RuneCountInString(v); runeCount > 3 {
+		cut := 0
+		seen := 0
+		for idx := range v {
+			if seen == runeCount-3 {
+				cut = idx
+				break
+			}
+			seen++
+		}
+		if err := emitText(v[:cut]); err != nil {
+			return err
+		}
+		v = v[cut:]
+	}
+	pending.Reset()
+	pending.WriteString(v)
+	return nil
+}

--- a/internal/web/stream_text_test.go
+++ b/internal/web/stream_text_test.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"strings"
+	"testing"
+
+	"m365-copilot2api/internal/chathub"
+)
+
+// collectStream feeds text fragments through streamEmitText the way the live
+// SSE loop does and returns everything that was emitted to the client plus the
+// residual pending buffer that a final flush would send.
+func collectStream(fragments []string) string {
+	emitted, pending := streamDuringAndPending(fragments)
+	// Final flush mirrors emitText(pending.String()) in the server.
+	return emitted + pending
+}
+
+// streamDuringAndPending returns (text emitted mid-stream, residual pending).
+func streamDuringAndPending(fragments []string) (string, string) {
+	var text, pending strings.Builder
+	var emitted strings.Builder
+	emit := func(part string) error {
+		emitted.WriteString(part)
+		return nil
+	}
+	for _, f := range fragments {
+		_ = streamEmitText(chathub.StreamEvent{Kind: "text", Text: f}, &text, &pending, emit)
+	}
+	return emitted.String(), pending.String()
+}
+
+// A ```text diagram followed by more prose and a second ```text block must be
+// delivered in full. The old buffering logic dropped everything after the first
+// completed fence, so the client answer was truncated at the diagram — exactly
+// the clash.yaml explanation regression.
+func TestStreamEmitsTextFencesAndTrailingProse(t *testing.T) {
+	full := "开头说明。\n\n```text\n浏览器 → Clash → 互联网\n```\n\n配置文件地址：\n\n```text\nhttp://1.2.3.4:8080/x/clash.yaml\n```\n\n其中 8080 只提供配置文件，443 才承载流量。结束。"
+	// Split into many small deltas to simulate token-by-token streaming.
+	var frags []string
+	for _, r := range full {
+		frags = append(frags, string(r))
+	}
+	got := collectStream(frags)
+	if got != full {
+		t.Fatalf("streamed output truncated.\n want %q\n  got %q", full, got)
+	}
+}
+
+// A tool-candidate fence (```bash) is withheld from the text stream mid-flight
+// so the post-stream extractor can convert or re-flush it; it must stay in the
+// pending buffer rather than being emitted as live text.
+func TestStreamWithholdsToolFence(t *testing.T) {
+	emitted, pending := streamDuringAndPending([]string{"运行：\n```bash\nls -la\n```"})
+	if strings.Contains(emitted, "ls -la") {
+		t.Fatalf("tool-candidate fence must not be emitted mid-stream, got %q", emitted)
+	}
+	if !strings.Contains(pending, "ls -la") {
+		t.Fatalf("tool-candidate fence should remain buffered in pending, got %q", pending)
+	}
+}
+
+// Ordinary prose with no fences streams through unchanged.
+func TestStreamPlainProse(t *testing.T) {
+	full := "这是一段没有代码块的普通回答，应该原样输出。"
+	var frags []string
+	for _, r := range full {
+		frags = append(frags, string(r))
+	}
+	if got := collectStream(frags); got != full {
+		t.Fatalf("plain prose altered.\n want %q\n  got %q", full, got)
+	}
+}

--- a/internal/web/tool_dedup_test.go
+++ b/internal/web/tool_dedup_test.go
@@ -1,0 +1,42 @@
+package web
+
+import "testing"
+
+// The M365 Copilot upstream sometimes emits the same fenced command twice in a
+// single reply. Without dedupe each copy becomes a separate tool round and the
+// agent ledger falsely trips the stuck-loop guard, producing a 409. dedupe must
+// collapse identical name+arguments while preserving order and the first id.
+func TestDedupeToolCallsCollapsesIdenticalCalls(t *testing.T) {
+	calls := []detectedToolCall{
+		{ID: "call_1", Name: "bash", Arguments: []byte(`{"command":"ls"}`)},
+		{ID: "call_2", Name: "bash", Arguments: []byte(`{"command":"ls"}`)},
+	}
+	got := dedupeToolCalls(calls)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call after dedupe, got %d", len(got))
+	}
+	if got[0].ID != "call_1" {
+		t.Fatalf("first occurrence should win, got id %q", got[0].ID)
+	}
+}
+
+func TestDedupeToolCallsTreatsEquivalentJSONAsSame(t *testing.T) {
+	calls := []detectedToolCall{
+		{ID: "call_1", Name: "write", Arguments: []byte(`{"path":"a","content":"x"}`)},
+		{ID: "call_2", Name: "write", Arguments: []byte(` { "content":"x", "path":"a" } `)},
+	}
+	if got := dedupeToolCalls(calls); len(got) != 1 {
+		t.Fatalf("equivalent JSON args should dedupe, got %d", len(got))
+	}
+}
+
+func TestDedupeToolCallsKeepsDistinctCalls(t *testing.T) {
+	calls := []detectedToolCall{
+		{ID: "call_1", Name: "bash", Arguments: []byte(`{"command":"ls"}`)},
+		{ID: "call_2", Name: "bash", Arguments: []byte(`{"command":"pwd"}`)},
+		{ID: "call_3", Name: "read", Arguments: []byte(`{"path":"a"}`)},
+	}
+	if got := dedupeToolCalls(calls); len(got) != 3 {
+		t.Fatalf("distinct calls must be preserved, got %d", len(got))
+	}
+}

--- a/internal/web/toolloop.go
+++ b/internal/web/toolloop.go
@@ -110,6 +110,29 @@ func callID(name, args string, index int) string {
 	return "call_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 }
 
+// dedupeToolCalls collapses tool calls that share the same name and canonical
+// arguments within a single upstream turn. The M365 Copilot upstream sometimes
+// emits the same fenced command (or native tool event) more than once in one
+// reply; without this the agent ledger counts each copy as a separate round and
+// falsely trips the stuck-loop guard (agent_ledger.go). Order is preserved and
+// the first occurrence wins so downstream call ids stay stable.
+func dedupeToolCalls(calls []detectedToolCall) []detectedToolCall {
+	if len(calls) < 2 {
+		return calls
+	}
+	seen := make(map[string]bool, len(calls))
+	out := calls[:0]
+	for _, c := range calls {
+		key := c.Name + "\x00" + canonicalToolArguments(string(c.Arguments))
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, c)
+	}
+	return out
+}
+
 func extractToolCalls(text string, tools []map[string]any, choice any) ([]detectedToolCall, bool) {
 	allowed := allowedToolNames(tools)
 	var out []detectedToolCall


### PR DESCRIPTION
## 问题

`/v1/images/generations` 只解析并使用**单个**账号。当上游因图片配额耗尽而拒绝时（模型返回 0 张图 + 配额话术），网关直接返回 `HTTP 429`，即使账号池里其他账号仍有图片额度也无法使用。

## 修复

- 配额拒绝时把该账号标记 `MarkImageLimited`（24h 冷却），并**轮换到下一个健康账号重试**
- 轮换时通过 `ImageGenAvailable` 跳过已知配额耗尽 / 冷却中的账号
- 仅当**所有**账号都耗尽才返回 429
- 调用方显式指定账号（`accountId` / `user`）时**不轮换**，尊重指定
- 非配额类的空返回（generic empty）不跨账号重试，按原逻辑报 502

## 测试

新增 `TestMarkImageLimitedBlocksAvailability`：验证 `MarkImageLimited` 后账号进入冷却且不影响其他账号。

`go build ./...` 与 `go test ./...` 通过。已在部署环境验证：配额耗尽的账号被标记后自动轮换到其他账号并成功出图。