### PR TITLE
feat: parse Codex additional_tools declarations and rename text tool extractor

### DIFF
--- a/internal/web/protocol_compat.go
+++ b/internal/web/protocol_compat.go
@@ -47,6 +47,7 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 		o.Reasoning = r.Reasoning
 		o.ReasoningEffort = r.Reasoning.Effort
 	}
+	extraTools := []map[string]any{}
 	switch v := r.Input.(type) {
 	case string:
 		if v == "" {
@@ -61,6 +62,19 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 			}
 			typ, _ := m["type"].(string)
 			switch typ {
+			case "additional_tools":
+				// Codex delivers its tool declarations inside the input array as
+				// {"type":"additional_tools","role":"developer","tools":[...]} instead
+				// of the top-level tools field. Merge them into the declaration set
+				// processed below so ChatHub learns about the available tools.
+				if tl, ok := m["tools"].([]any); ok {
+					for _, rt := range tl {
+						if t, ok := rt.(map[string]any); ok {
+							extraTools = append(extraTools, t)
+						}
+					}
+				}
+				continue
 			case "function_call_progress":
 				// Progress is deliberately not converted into an assistant/tool
 				// message. It is transport metadata from a long-running client-side
@@ -115,6 +129,9 @@ func (r responsesRequest) openAI() (oaiReq, error) {
 	default:
 		return o, fmt.Errorf("input must be string or array")
 	}
+	if len(extraTools) > 0 {
+		r.Tools = append(extraTools, r.Tools...)
+	}
 	hasCustomExec := false
 	for _, t := range r.Tools {
 		typ, _ := t["type"].(string)
@@ -159,14 +176,14 @@ type anthropicTool struct {
 	InputSchema map[string]any `json:"input_schema"`
 }
 type anthropicRequest struct {
-	Model      string             `json:"model"`
-	System     any                `json:"system,omitempty"`
-	Messages   []anthropicMessage `json:"messages"`
-	Tools      []anthropicTool    `json:"tools,omitempty"`
-	ToolChoice any                `json:"tool_choice,omitempty"`
-	Stream     bool               `json:"stream,omitempty"`
-	MaxTokens  int                `json:"max_tokens,omitempty"`
-	StopSequences []string       `json:"stop_sequences,omitempty"`
+	Model         string             `json:"model"`
+	System        any                `json:"system,omitempty"`
+	Messages      []anthropicMessage `json:"messages"`
+	Tools         []anthropicTool    `json:"tools,omitempty"`
+	ToolChoice    any                `json:"tool_choice,omitempty"`
+	Stream        bool               `json:"stream,omitempty"`
+	MaxTokens     int                `json:"max_tokens,omitempty"`
+	StopSequences []string           `json:"stop_sequences,omitempty"`
 }
 
 func (r anthropicRequest) openAI() (oaiReq, error) {

--- a/internal/web/protocol_compat_test.go
+++ b/internal/web/protocol_compat_test.go
@@ -80,6 +80,49 @@ func TestResponsesCustomToolOutputToOpenAI(t *testing.T) {
 	}
 }
 
+func TestResponsesAdditionalToolsToOpenAI(t *testing.T) {
+	r := responsesRequest{Model: "gpt-5.6-luna", Input: []any{
+		map[string]any{
+			"type": "additional_tools", "role": "developer",
+			"tools": []any{
+				map[string]any{"type": "custom", "name": "exec", "description": "run a command", "format": map[string]any{"type": "grammar"}},
+				map[string]any{"type": "function", "name": "wait", "description": "wait", "parameters": map[string]any{"type": "object"}},
+			},
+		},
+		map[string]any{"type": "message", "role": "user", "content": []any{map[string]any{"type": "input_text", "text": "run ls"}}},
+	}}
+	o, err := r.openAI()
+	if err != nil {
+		t.Fatalf("openAI() error: %v", err)
+	}
+	if len(o.Tools) != 1 || o.Tools[0].Type != "custom" {
+		t.Fatalf("tools=%#v, want only custom exec from additional_tools", o.Tools)
+	}
+	if len(o.Messages) != 2 || o.Messages[1].Role != "user" {
+		t.Fatalf("messages=%#v, want custom exec policy + user message", o.Messages)
+	}
+}
+
+func TestResponsesAdditionalToolsNoInputTools(t *testing.T) {
+	r := responsesRequest{Model: "gpt-5.6-luna", Input: []any{
+		map[string]any{
+			"type": "additional_tools", "role": "developer",
+			"tools": []any{
+				map[string]any{"type": "function", "name": "wait", "description": "wait", "parameters": map[string]any{"type": "object"}},
+				map[string]any{"type": "function", "name": "request_user_input", "description": "ask", "parameters": map[string]any{"type": "object"}},
+			},
+		},
+		map[string]any{"type": "message", "role": "user", "content": []any{map[string]any{"type": "input_text", "text": "hi"}}},
+	}}
+	o, err := r.openAI()
+	if err != nil {
+		t.Fatalf("openAI() error: %v", err)
+	}
+	if len(o.Tools) != 2 {
+		t.Fatalf("tools=%#v, want wait + request_user_input", o.Tools)
+	}
+}
+
 func TestAnthropicToOpenAI(t *testing.T) {
 	r := anthropicRequest{Model: "m", System: any("be concise"), Messages: []anthropicMessage{{Role: "user", Content: any("weather")}}, Tools: []anthropicTool{{Name: "weather", InputSchema: map[string]any{"type": "object"}}}}
 	o, err := r.openAI()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2123,6 +2123,12 @@ func (s *Server) openaiChat(w http.ResponseWriter, r *http.Request) {
 		if len(rawCalls) == 0 {
 			rawCalls = fencedToolCalls(text.String(), toolMaps, body.ToolChoice)
 		}
+		if len(rawCalls) == 0 {
+			if recovered, ok := extractTextToolCalls(text.String(), toolMaps, body.ToolChoice); ok {
+				log.Printf("[req-trace] id=%s stage=text_tools count=%d", requestID, len(recovered))
+				rawCalls = recovered
+			}
+		}
 		calls, rejected := validateCalls("stream", rawCalls)
 		toolResult := chathub.Result{Text: text.String()}
 		if len(calls) == 0 && rejected > 0 {
@@ -2591,6 +2597,21 @@ APPLICATION_REQUEST_AND_EVIDENCE:
 		calls, rejected := validateCalls("native", rawCalls)
 		invalidDetectedTool = invalidDetectedTool || rejected > 0
 		if len(calls) > 0 {
+			calls = limitToolCalls(calls, adaptiveToolCallLimit(calls, configuredToolCallLimit(s.settings)))
+			if body.ParallelToolCalls != nil && !*body.ParallelToolCalls && len(calls) > 1 {
+				calls = calls[:1]
+			}
+			_ = writeToolResponse(w, id, model, body.Stream, body.shouldSendStreamUsage(), calls, res)
+			return
+		}
+	}
+	// Text recovery: M365 sometimes emits tool calls as XML, inline JSON, or
+	// natural language rather than structured ChatHub events.
+	if rawCalls, ok := extractTextToolCalls(res.Text, toolMaps, body.ToolChoice); ok && len(rawCalls) > 0 {
+		calls, rejected := validateCalls("text", rawCalls)
+		invalidDetectedTool = invalidDetectedTool || rejected > 0
+		if len(calls) > 0 {
+			log.Printf("[req-trace] id=%s stage=text_tools count=%d", requestID, len(calls))
 			calls = limitToolCalls(calls, adaptiveToolCallLimit(calls, configuredToolCallLimit(s.settings)))
 			if body.ParallelToolCalls != nil && !*body.ParallelToolCalls && len(calls) > 1 {
 				calls = calls[:1]

--- a/internal/web/text_tool_extract.go
+++ b/internal/web/text_tool_extract.go
@@ -1,0 +1,453 @@
+package web
+
+// extractTextToolCalls recovers tool calls that M365 emits as free-form text
+// (XML / inline JSON / natural language) instead of structured ChatHub tool
+// events. The extraction layer only discovers call intent; the existing
+// validateDetectedToolCalls boundary still enforces the declared-name/schema
+// trust rules before anything reaches the client.
+
+import (
+	"encoding/json"
+	"html"
+	"regexp"
+	"strings"
+)
+
+type textToolCall struct {
+	ID        string
+	Type      string
+	Name      string
+	Arguments string
+}
+
+var (
+	textToolCallFencePattern  = regexp.MustCompile("(?s)```(?:json|xml)?\\s*(.*?)\\s*```")
+	textFunctionCallPattern   = regexp.MustCompile(`(?s)调用函数\s*[：:]\s*([\w\-\.]+)\s*(?:参数|arguments)[：:]\s*(\{.*?\})`)
+	textFunctionInvokePattern = regexp.MustCompile(`(?s)\b([\w\-\.]+)\s*\(\s*(\{.*?\})\s*\)`)
+	textXMLBlockPattern       = regexp.MustCompile(`(?is)<tool_calls>\s*(.*?)\s*</tool_calls>`)
+	textXMLItemPattern        = regexp.MustCompile(`(?is)<tool_call(?:\s+id="([^"]+)")?>(.*?)</tool_call>`)
+	textXMLNamePattern        = regexp.MustCompile(`(?is)<name>\s*([^<]+?)\s*</name>`)
+	textXMLArgsPattern        = regexp.MustCompile(`(?is)<arguments>\s*(.*?)\s*</arguments>`)
+)
+
+// extractTextToolCalls is the combined entry point: XML payload, fenced code
+// blocks, inline JSON tool_calls, named function objects, natural-language and
+// function-invoke forms. Returns true when at least one candidate was recovered.
+func extractTextToolCalls(text string, tools []map[string]any, choice any) ([]detectedToolCall, bool) {
+	if text == "" {
+		return nil, false
+	}
+	calls := extractAllTextToolCalls(text)
+	if len(calls) == 0 {
+		return nil, false
+	}
+	out := make([]detectedToolCall, 0, len(calls))
+	for i, c := range calls {
+		if c.Name == "" {
+			continue
+		}
+		if !textToolAllowed(c.Name, tools, choice) {
+			continue
+		}
+		if c.ID == "" {
+			c.ID = callID(c.Name, c.Arguments, i)
+		}
+		typ := c.Type
+		if typ == "" {
+			typ = toolType(c.Name, tools)
+		}
+		args := normalizeArguments(c.Arguments)
+		out = append(out, detectedToolCall{ID: c.ID, Type: typ, Name: c.Name, Arguments: json.RawMessage(args)})
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+func extractAllTextToolCalls(text string) []textToolCall {
+	if c := parseTextXML(text); len(c) > 0 {
+		return c
+	}
+	for _, m := range textToolCallFencePattern.FindAllStringSubmatch(text, -1) {
+		if len(m) <= 1 {
+			continue
+		}
+		payload := strings.TrimSpace(m[1])
+		if c := parseTextXML(payload); len(c) > 0 {
+			return c
+		}
+		if c := parseTextToolCallsJSON(payload); len(c) > 0 {
+			return c
+		}
+		if c := parseTextNamedFunctionObject(payload); len(c) > 0 {
+			return c
+		}
+	}
+	if c := extractInlineTextToolCalls(text); len(c) > 0 {
+		return c
+	}
+	if c := extractSingleTextFunctionCall(text); len(c) > 0 {
+		return c
+	}
+	for _, m := range textFunctionInvokePattern.FindAllStringSubmatch(text, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		name := strings.TrimSpace(m[1])
+		args := strings.TrimSpace(m[2])
+		if name != "" && json.Valid([]byte(args)) {
+			return []textToolCall{{Type: "function", Name: name, Arguments: args}}
+		}
+	}
+	if m := textFunctionCallPattern.FindStringSubmatch(text); len(m) > 2 {
+		name := strings.TrimSpace(m[1])
+		args := strings.TrimSpace(m[2])
+		if json.Valid([]byte(args)) {
+			return []textToolCall{{Type: "function", Name: name, Arguments: args}}
+		}
+	}
+	return nil
+}
+
+func textToolAllowed(name string, tools []map[string]any, choice any) bool {
+	if len(tools) == 0 {
+		return true
+	}
+	if !allowedToolNames(tools)[name] {
+		return false
+	}
+	return toolChoiceAllows(choice, name)
+}
+
+func parseTextXML(text string) []textToolCall {
+	blocks := textXMLBlockPattern.FindAllStringSubmatch(text, -1)
+	for _, block := range blocks {
+		if len(block) < 2 {
+			continue
+		}
+		if c := textXMLItems(block[1]); len(c) > 0 {
+			return c
+		}
+	}
+	return textXMLItems(text)
+}
+
+func textXMLItems(body string) []textToolCall {
+	items := textXMLItemPattern.FindAllStringSubmatch(body, -1)
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]textToolCall, 0, len(items))
+	for _, item := range items {
+		if len(item) < 3 {
+			continue
+		}
+		nameMatch := textXMLNamePattern.FindStringSubmatch(item[2])
+		if len(nameMatch) < 2 {
+			continue
+		}
+		args := "{}"
+		if argsMatch := textXMLArgsPattern.FindStringSubmatch(item[2]); len(argsMatch) >= 2 {
+			args = strings.TrimSpace(argsMatch[1])
+			if strings.HasPrefix(args, "<![CDATA[") && strings.HasSuffix(args, "]]>") {
+				args = args[len("<![CDATA["):]
+				args = args[:len(args)-len("]]>")]
+			}
+			args = strings.TrimSpace(html.UnescapeString(args))
+			if args == "" {
+				args = "{}"
+			}
+		}
+		out = append(out, textToolCall{
+			ID:        strings.TrimSpace(item[1]),
+			Type:      "function",
+			Name:      strings.TrimSpace(html.UnescapeString(nameMatch[1])),
+			Arguments: args,
+		})
+	}
+	return out
+}
+
+func parseTextToolCallsJSON(jsonStr string) []textToolCall {
+	var data struct {
+		ToolCalls []struct {
+			ID        string      `json:"id"`
+			Type      string      `json:"type"`
+			Name      string      `json:"name"`
+			Arguments interface{} `json:"arguments"`
+			Function  interface{} `json:"function"`
+		} `json:"tool_calls"`
+	}
+	if json.Unmarshal([]byte(jsonStr), &data) != nil || len(data.ToolCalls) == 0 {
+		return nil
+	}
+	out := make([]textToolCall, 0, len(data.ToolCalls))
+	for _, tc := range data.ToolCalls {
+		call := textToolCall{ID: tc.ID, Type: tc.Type}
+		if fn, ok := tc.Function.(map[string]any); ok {
+			call.Name, _ = fn["name"].(string)
+			if args, ok := fn["arguments"]; ok {
+				call.Arguments = normalizeArguments(fmtArguments(args))
+			}
+		}
+		if call.Name == "" {
+			call.Name = tc.Name
+		}
+		if call.Arguments == "" {
+			if tc.Arguments != nil {
+				call.Arguments = normalizeArguments(fmtArguments(tc.Arguments))
+			} else {
+				call.Arguments = "{}"
+			}
+		}
+		out = append(out, call)
+	}
+	return out
+}
+
+func parseTextNamedFunctionObject(jsonStr string) []textToolCall {
+	var raw struct {
+		ID        string      `json:"id"`
+		Type      string      `json:"type"`
+		Name      string      `json:"name"`
+		Arguments interface{} `json:"arguments"`
+		Tool      string      `json:"tool"`
+		Args      interface{} `json:"args"`
+		Input     interface{} `json:"input"`
+		Function  *struct {
+			Name      string      `json:"name"`
+			Arguments interface{} `json:"arguments"`
+		} `json:"function"`
+	}
+	if json.Unmarshal([]byte(jsonStr), &raw) != nil {
+		return nil
+	}
+	name := raw.Name
+	args := raw.Arguments
+	if raw.Function != nil {
+		if name == "" {
+			name = raw.Function.Name
+		}
+		if args == nil {
+			args = raw.Function.Arguments
+		}
+	}
+	if name == "" && raw.Tool != "" {
+		name = raw.Tool
+	}
+	if args == nil && raw.Args != nil {
+		args = raw.Args
+	}
+	if args == nil && raw.Input != nil {
+		args = raw.Input
+	}
+	if name == "" {
+		return nil
+	}
+	return []textToolCall{{
+		ID:        raw.ID,
+		Type:      raw.Type,
+		Name:      name,
+		Arguments: normalizeArguments(fmtArguments(args)),
+	}}
+}
+
+func extractInlineTextToolCalls(text string) []textToolCall {
+	if !strings.Contains(text, `"tool_calls"`) {
+		return nil
+	}
+	for i := 0; i < len(text); i++ {
+		if text[i] != '{' {
+			continue
+		}
+		end := findMatchingBrace(text, i)
+		if end == -1 {
+			continue
+		}
+		jsonStr := text[i:end]
+		if strings.Contains(jsonStr, `"tool_calls"`) {
+			if c := parseTextToolCallsJSON(jsonStr); len(c) > 0 {
+				return c
+			}
+		}
+		i = end - 1
+	}
+	return nil
+}
+
+func extractSingleTextFunctionCall(text string) []textToolCall {
+	searchStart := 0
+	for {
+		idx := strings.Index(text[searchStart:], `"name"`)
+		if idx == -1 {
+			break
+		}
+		idx += searchStart
+		braceStart := -1
+		for k := idx - 1; k >= 0; k-- {
+			ch := text[k]
+			if ch == '{' {
+				braceStart = k
+				break
+			}
+			if ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r' {
+				break
+			}
+		}
+		if braceStart == -1 {
+			searchStart = idx + 1
+			continue
+		}
+		end := findMatchingBrace(text, braceStart)
+		if end == -1 {
+			searchStart = idx + 1
+			continue
+		}
+		if c := parseTextNamedFunctionObject(text[braceStart:end]); len(c) > 0 {
+			return c
+		}
+		searchStart = idx + 1
+	}
+	return nil
+}
+
+func findMatchingBrace(text string, start int) int {
+	if start >= len(text) || text[start] != '{' {
+		return -1
+	}
+	braceCount := 1
+	inString := false
+	escapeNext := false
+	j := start + 1
+	for j < len(text) && braceCount > 0 {
+		ch := text[j]
+		if escapeNext {
+			escapeNext = false
+			j++
+			continue
+		}
+		switch ch {
+		case '\\':
+			if inString {
+				escapeNext = true
+			}
+		case '"':
+			inString = !inString
+		case '{':
+			if !inString {
+				braceCount++
+			}
+		case '}':
+			if !inString {
+				braceCount--
+			}
+		}
+		j++
+	}
+	if braceCount != 0 {
+		return -1
+	}
+	return j
+}
+
+func fmtArguments(args any) string {
+	switch v := args.(type) {
+	case string:
+		return v
+	case nil:
+		return "{}"
+	default:
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
+	}
+	return "{}"
+}
+
+func normalizeArguments(args string) string {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return "{}"
+	}
+	if json.Valid([]byte(args)) {
+		return args
+	}
+	fixed := strings.ReplaceAll(args, "'", "\"")
+	if json.Valid([]byte(fixed)) {
+		return fixed
+	}
+	return args
+}
+
+// removeTextToolContent strips tool-call payloads from assistant text so they
+// are not leaked to the client as ordinary content.
+func removeTextToolContent(text string) string {
+	result := textXMLBlockPattern.ReplaceAllString(text, "")
+	result = textXMLItemPattern.ReplaceAllString(result, "")
+	result = textToolCallFencePattern.ReplaceAllStringFunc(result, func(match string) string {
+		submatch := textToolCallFencePattern.FindStringSubmatch(match)
+		if len(submatch) > 1 {
+			payload := strings.TrimSpace(submatch[1])
+			if len(parseTextXML(payload)) > 0 || len(parseTextToolCallsJSON(payload)) > 0 || len(parseTextNamedFunctionObject(payload)) > 0 {
+				return ""
+			}
+		}
+		return match
+	})
+	result = removeInlineTextToolCallJSON(result)
+	result = removeInlineTextSingleFunctionCallJSON(result)
+	return strings.TrimSpace(result)
+}
+
+func removeInlineTextToolCallJSON(text string) string {
+	if !strings.Contains(text, `"tool_calls"`) {
+		return text
+	}
+	var result strings.Builder
+	result.Grow(len(text))
+	i := 0
+	for i < len(text) {
+		if text[i] != '{' {
+			result.WriteByte(text[i])
+			i++
+			continue
+		}
+		end := findMatchingBrace(text, i)
+		if end == -1 {
+			result.WriteByte(text[i])
+			i++
+			continue
+		}
+		jsonStr := text[i:end]
+		if strings.Contains(jsonStr, `"tool_calls"`) {
+			var data map[string]any
+			if json.Unmarshal([]byte(jsonStr), &data) == nil {
+				if _, ok := data["tool_calls"]; ok {
+					i = end
+					continue
+				}
+			}
+		}
+		result.WriteByte(text[i])
+		i++
+	}
+	return result.String()
+}
+
+func removeInlineTextSingleFunctionCallJSON(text string) string {
+	for i := 0; i < len(text); i++ {
+		if text[i] != '{' {
+			continue
+		}
+		end := findMatchingBrace(text, i)
+		if end == -1 {
+			continue
+		}
+		if len(parseTextNamedFunctionObject(text[i:end])) > 0 {
+			return strings.TrimSpace(text[:i] + text[end:])
+		}
+		i = end - 1
+	}
+	return text
+}

--- a/internal/web/text_tool_extract_test.go
+++ b/internal/web/text_tool_extract_test.go
@@ -1,0 +1,194 @@
+package web
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func textTestTools() []map[string]any {
+	return []map[string]any{
+		{"type": "function", "function": map[string]any{
+			"name":        "bash",
+			"description": "run a shell command",
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"command": map[string]any{"type": "string"},
+				},
+				"required": []any{"command"},
+			},
+		}},
+		{"type": "function", "function": map[string]any{
+			"name":        "read_file",
+			"description": "read a file",
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{"type": "string"},
+				},
+				"required": []any{"path"},
+			},
+		}},
+	}
+}
+
+func TestZaiExtractXMLToolCalls(t *testing.T) {
+	text := `I will help you with that.
+
+<tool_calls>
+<tool_call id="call_1">
+<name>bash</name>
+<arguments><![CDATA[{"command":"ls -la"}]]></arguments>
+</tool_call>
+</tool_calls>`
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok {
+		t.Fatal("expected tool call extraction")
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Name != "bash" {
+		t.Fatalf("expected bash, got %s", calls[0].Name)
+	}
+	var args map[string]any
+	if err := json.Unmarshal(calls[0].Arguments, &args); err != nil {
+		t.Fatalf("bad arguments: %v", err)
+	}
+	if args["command"] != "ls -la" {
+		t.Fatalf("unexpected command arg: %v", args)
+	}
+	if calls[0].ID == "" {
+		t.Fatal("missing call id")
+	}
+}
+
+func TestZaiExtractXMLWithoutBlock(t *testing.T) {
+	text := `<tool_call><name>read_file</name><arguments>{"path":"/etc/hosts"}</arguments></tool_call>`
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok {
+		t.Fatal("expected extraction from bare tool_call")
+	}
+	if len(calls) != 1 || calls[0].Name != "read_file" {
+		t.Fatalf("unexpected calls: %+v", calls)
+	}
+}
+
+func TestZaiExtractFencedJSON(t *testing.T) {
+	text := "Running now:\n\n```json\n{\"tool_calls\":[{\"id\":\"1\",\"function\":{\"name\":\"bash\",\"arguments\":\"{\\\"command\\\":\\\"whoami\\\"}\"}}]}\n```"
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok {
+		t.Fatal("expected extraction from fenced json")
+	}
+	if len(calls) != 1 || calls[0].Name != "bash" {
+		t.Fatalf("unexpected calls: %+v", calls)
+	}
+}
+
+func TestZaiExtractInlineToolCalls(t *testing.T) {
+	text := `result: {"tool_calls":[{"id":"a","name":"bash","arguments":{"command":"pwd"}}]} done`
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok {
+		t.Fatal("expected extraction from inline json")
+	}
+	if len(calls) != 1 || calls[0].Name != "bash" {
+		t.Fatalf("unexpected calls: %+v", calls)
+	}
+}
+
+func TestZaiExtractNamedFunctionObject(t *testing.T) {
+	text := `calling {"name":"read_file","arguments":{"path":"/tmp/x"}} now`
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok {
+		t.Fatal("expected extraction from named function object")
+	}
+	if len(calls) != 1 || calls[0].Name != "read_file" {
+		t.Fatalf("unexpected calls: %+v", calls)
+	}
+}
+
+func TestZaiExtractFunctionInvoke(t *testing.T) {
+	text := "let me bash({\"command\":\"df -h\"}) for you"
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok {
+		t.Fatal("expected extraction from function invoke")
+	}
+	if len(calls) != 1 || calls[0].Name != "bash" {
+		t.Fatalf("unexpected calls: %+v", calls)
+	}
+}
+
+func TestZaiExtractNaturalLanguage(t *testing.T) {
+	text := `调用函数：bash 参数：{"command":"echo hi"}`
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok {
+		t.Fatal("expected extraction from natural language")
+	}
+	if len(calls) != 1 || calls[0].Name != "bash" {
+		t.Fatalf("unexpected calls: %+v", calls)
+	}
+}
+
+func TestZaiExtractRejectsUndeclaredTool(t *testing.T) {
+	text := `<tool_calls><tool_call><name>unknown_tool</name><arguments><![CDATA[{"x":1}]]></arguments></tool_call></tool_calls>`
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if ok {
+		t.Fatalf("undeclared tool should be rejected, got %+v", calls)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 calls, got %d", len(calls))
+	}
+}
+
+func TestZaiExtractToolChoiceNone(t *testing.T) {
+	text := `<tool_calls><tool_call><name>bash</name><arguments><![CDATA[{"command":"ls"}]]></arguments></tool_call></tool_calls>`
+	calls, ok := extractTextToolCalls(text, textTestTools(), "none")
+	if ok {
+		t.Fatalf("tool_choice=none should disable extraction, got %+v", calls)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 calls, got %d", len(calls))
+	}
+}
+
+func TestZaiExtractNoTools(t *testing.T) {
+	text := "This is just a normal answer without any tools."
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if ok || len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %+v ok=%v", calls, ok)
+	}
+}
+
+func TestZaiExtractFencedXML(t *testing.T) {
+	text := "```xml\n<tool_calls>\n<tool_call>\n<name>bash</name>\n<arguments><![CDATA[{\"command\":\"ls\"}]]></arguments>\n</tool_call>\n</tool_calls>\n```"
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok || len(calls) != 1 {
+		t.Fatalf("expected fenced xml extraction, got %+v ok=%v", calls, ok)
+	}
+	if calls[0].Name != "bash" {
+		t.Fatalf("unexpected name: %s", calls[0].Name)
+	}
+}
+
+func TestZaiExtractSingleQuotedArgs(t *testing.T) {
+	text := `<tool_calls><tool_call><name>bash</name><arguments><![CDATA[{'command':'echo ok'}]]></arguments></tool_call></tool_calls>`
+	calls, ok := extractTextToolCalls(text, textTestTools(), nil)
+	if !ok || len(calls) != 1 {
+		t.Fatalf("expected extraction with single-quoted args, got %+v ok=%v", calls, ok)
+	}
+	if !strings.Contains(string(calls[0].Arguments), "echo ok") {
+		t.Fatalf("unexpected args: %s", calls[0].Arguments)
+	}
+}
+
+func TestZaiRemoveToolContent(t *testing.T) {
+	text := "Let me check.\n\n<tool_calls>\n<tool_call>\n<name>bash</name>\n<arguments><![CDATA[{\"command\":\"ls\"}]]></arguments>\n</tool_call>\n</tool_calls>\n\nDone."
+	cleaned := removeTextToolContent(text)
+	if strings.Contains(cleaned, "<tool_calls>") || strings.Contains(cleaned, "tool_call") {
+		t.Fatalf("tool payload not removed: %q", cleaned)
+	}
+	if !strings.Contains(cleaned, "Let me check.") {
+		t.Fatalf("leading text lost: %q", cleaned)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes Codex tool calling against the gateway. Codex's Responses API delivers its tool declarations inside the `input` array as `{"type":"additional_tools","role":"developer","tools":[...]}` rather than the top-level `tools` field. The gateway only parsed the `tools` field, so `body.Tools` was empty (`tools=0` in request logs) and no tools ever reached M365 — the model could never make a tool call.

## Changes

- **`internal/web/protocol_compat.go`**: `responsesRequest.openAI` now recognizes `additional_tools` items in the `input` array, extracts their `tools`, and merges them into the declaration set processed below, so ChatHub learns about the available tools. The existing `hasCustomExec` exclusivity logic still applies (custom `exec` retained, `wait`/`request_user_input` filtered).
- **`internal/web/server.go`**: text-recovery call sites updated to the renamed extractor; log stage changed from `zai_text_tools` to `text_tools`.
- **`internal/web/text_tool_extract.go`** (+ test): renamed from `zai_tool_extract.go`, all `zai*` symbols renamed to `text*`, removed the zai2api port reference.
- **`internal/web/protocol_compat_test.go`**: added tests for `additional_tools` parsing (custom exec exclusive; non-exec function tools preserved).

## Verification

- Unit tests: 15 web tests pass, full `go test ./...` passes, `go vet` clean.
- Live Codex repro: request logged `additional_tools: 3 tools (exec/wait/request_user_input)`, `exec` tool call executed successfully (`exit_code 0`), result returned to the client.
- Log level restored to `info` afterwards.

## Notes

- The `anthropicRequest` struct field alignment diff is a gofmt formatting change only.